### PR TITLE
Several smaller fixed, e.g. translations, import error for specific c…

### DIFF
--- a/agent/src/Endpoints/CronCreateEndpoint.php
+++ b/agent/src/Endpoints/CronCreateEndpoint.php
@@ -39,6 +39,7 @@ declare(strict_types=1);
 namespace Cronmanager\Agent\Endpoints;
 
 use Cronmanager\Agent\Cron\CrontabManager;
+use Cron\CronExpression;
 use Monolog\Logger;
 use PDO;
 use PDOException;
@@ -371,35 +372,33 @@ final class CronCreateEndpoint
     }
 
     /**
-     * Basic cron schedule expression validator.
+     * Validate a cron schedule expression using dragonmantank/cron-expression.
+     *
+     * Accepts standard 5-field cron expressions (including named day/month
+     * abbreviations such as "sat", "jan") as well as the @ shorthand forms
+     * supported by the library (@daily, @weekly, @monthly, @yearly, @annually,
+     * @midnight, @hourly, @reboot).
      *
      * @param string $schedule Cron expression to validate.
      *
-     * @return bool True when the expression looks like a valid cron schedule.
+     * @return bool True when the expression is valid.
      */
     private function isValidCronSchedule(string $schedule): bool
     {
-        $fields = preg_split('/\s+/', trim($schedule));
+        $trimmed = trim($schedule);
 
-        if ($fields === false) {
+        // @reboot is a valid vixie-cron directive but is not a time expression
+        // and is therefore not supported by dragonmantank/cron-expression.
+        if (strtolower($trimmed) === '@reboot') {
+            return true;
+        }
+
+        try {
+            new CronExpression($trimmed);
+            return true;
+        } catch (\InvalidArgumentException) {
             return false;
         }
-
-        $count = count($fields);
-
-        if ($count < 5 || $count > 6) {
-            return false;
-        }
-
-        $fieldPattern = '/^[\d*\/,\-]+$/';
-
-        foreach ($fields as $field) {
-            if (!preg_match($fieldPattern, $field)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/agent/src/Endpoints/CronUpdateEndpoint.php
+++ b/agent/src/Endpoints/CronUpdateEndpoint.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Cronmanager\Agent\Endpoints;
 
 use Cronmanager\Agent\Cron\CrontabManager;
+use Cron\CronExpression;
 use Monolog\Logger;
 use PDO;
 use PDOException;
@@ -586,34 +587,32 @@ final class CronUpdateEndpoint
     }
 
     /**
-     * Basic cron schedule expression validator.
+     * Validate a cron schedule expression using dragonmantank/cron-expression.
+     *
+     * Accepts standard 5-field cron expressions (including named day/month
+     * abbreviations such as "sat", "jan") as well as the @ shorthand forms
+     * supported by the library (@daily, @weekly, @monthly, @yearly, @annually,
+     * @midnight, @hourly, @reboot).
      *
      * @param string $schedule Cron expression to validate.
      *
-     * @return bool
+     * @return bool True when the expression is valid.
      */
     private function isValidCronSchedule(string $schedule): bool
     {
-        $fields = preg_split('/\s+/', trim($schedule));
+        $trimmed = trim($schedule);
 
-        if ($fields === false) {
+        // @reboot is a valid vixie-cron directive but is not a time expression
+        // and is therefore not supported by dragonmantank/cron-expression.
+        if (strtolower($trimmed) === '@reboot') {
+            return true;
+        }
+
+        try {
+            new CronExpression($trimmed);
+            return true;
+        } catch (\InvalidArgumentException) {
             return false;
         }
-
-        $count = count($fields);
-
-        if ($count < 5 || $count > 6) {
-            return false;
-        }
-
-        $fieldPattern = '/^[\d*\/,\-]+$/';
-
-        foreach ($fields as $field) {
-            if (!preg_match($fieldPattern, $field)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/web/lang/de.php
+++ b/web/lang/de.php
@@ -119,6 +119,7 @@ return [
     // -------------------------------------------------------------------------
     'timeline_title'          => 'Zeitachse',
     'timeline_no_results'     => 'Keine Ausführungen gefunden.',
+    'timeline_showing'        => '{from}–{to} von {total} Ausführungen',
 
     // -------------------------------------------------------------------------
     // Swimlane
@@ -132,6 +133,24 @@ return [
     'swimlane_all_days'       => 'Alle Tage',
     'swimlane_no_results'     => 'Keine Jobs im gewählten Zeitbereich geplant.',
     'swimlane_no_results_hint'=> 'Stunden erweitern oder „Alle Tage" wählen.',
+    // Info-Leiste / Tooltip JS-Strings
+    'swimlane_time_prefix'    => 'Zeit:',
+    'swimlane_day_prefix'     => 'Tag:',
+    'swimlane_job_singular'   => 'Job',
+    'swimlane_job_plural'     => 'Jobs',
+    'swimlane_shown'          => 'angezeigt',
+    'swimlane_next_prefix'    => 'Nächster:',
+    'swimlane_at'             => 'um',
+    'swimlane_in_prefix'      => 'in',
+    'swimlane_min'            => 'Min.',
+    'swimlane_hour_abbr'      => 'Std.',
+    'swimlane_inactive_warning' => '⚠ Job ist inaktiv',
+    'sw_schedule'             => 'Zeitplan',
+    'sw_meaning'              => 'Bedeutung',
+    'sw_fires_at'             => 'Startet um',
+    'sw_target'               => 'Ziel',
+    'sw_user'                 => 'Benutzer',
+    'sw_tags'                 => 'Tags',
     'day_monday'              => 'Montag',
     'day_tuesday'             => 'Dienstag',
     'day_wednesday'           => 'Mittwoch',
@@ -139,6 +158,19 @@ return [
     'day_friday'              => 'Freitag',
     'day_saturday'            => 'Samstag',
     'day_sunday'              => 'Sonntag',
+    // Monatsnamen (für lokalisierte Datumsformatierung)
+    'month_1'                 => 'Januar',
+    'month_2'                 => 'Februar',
+    'month_3'                 => 'März',
+    'month_4'                 => 'April',
+    'month_5'                 => 'Mai',
+    'month_6'                 => 'Juni',
+    'month_7'                 => 'Juli',
+    'month_8'                 => 'August',
+    'month_9'                 => 'September',
+    'month_10'                => 'Oktober',
+    'month_11'                => 'November',
+    'month_12'                => 'Dezember',
 
     // -------------------------------------------------------------------------
     // Export

--- a/web/lang/en.php
+++ b/web/lang/en.php
@@ -119,6 +119,7 @@ return [
     // -------------------------------------------------------------------------
     'timeline_title'          => 'Timeline',
     'timeline_no_results'     => 'No executions found.',
+    'timeline_showing'        => 'Showing {from}–{to} of {total} executions',
 
     // -------------------------------------------------------------------------
     // Swimlane
@@ -132,6 +133,24 @@ return [
     'swimlane_all_days'       => 'All days',
     'swimlane_no_results'     => 'No jobs scheduled in this time range.',
     'swimlane_no_results_hint'=> 'Try expanding the hours or switching to "All days".',
+    // Info bar / tooltip JS strings
+    'swimlane_time_prefix'    => 'Time:',
+    'swimlane_day_prefix'     => 'Day:',
+    'swimlane_job_singular'   => 'job',
+    'swimlane_job_plural'     => 'jobs',
+    'swimlane_shown'          => 'shown',
+    'swimlane_next_prefix'    => 'Next:',
+    'swimlane_at'             => 'at',
+    'swimlane_in_prefix'      => 'in',
+    'swimlane_min'            => 'min',
+    'swimlane_hour_abbr'      => 'h',
+    'swimlane_inactive_warning' => '⚠ Job is inactive',
+    'sw_schedule'             => 'Schedule',
+    'sw_meaning'              => 'Meaning',
+    'sw_fires_at'             => 'Fires at',
+    'sw_target'               => 'Target',
+    'sw_user'                 => 'User',
+    'sw_tags'                 => 'Tags',
     'day_monday'              => 'Monday',
     'day_tuesday'             => 'Tuesday',
     'day_wednesday'           => 'Wednesday',
@@ -139,6 +158,19 @@ return [
     'day_friday'              => 'Friday',
     'day_saturday'            => 'Saturday',
     'day_sunday'              => 'Sunday',
+    // Month names (used for locale-aware date formatting)
+    'month_1'                 => 'January',
+    'month_2'                 => 'February',
+    'month_3'                 => 'March',
+    'month_4'                 => 'April',
+    'month_5'                 => 'May',
+    'month_6'                 => 'June',
+    'month_7'                 => 'July',
+    'month_8'                 => 'August',
+    'month_9'                 => 'September',
+    'month_10'                => 'October',
+    'month_11'                => 'November',
+    'month_12'                => 'December',
 
     // -------------------------------------------------------------------------
     // Export

--- a/web/src/Controller/CronController.php
+++ b/web/src/Controller/CronController.php
@@ -199,6 +199,11 @@ class CronController extends BaseController
         // SSH host selector dynamically when the linux_user field changes.
         $sshHostsByUser = $this->fetchSshHostsByUser();
 
+        $returnUrl = trim((string) ($_GET['_return'] ?? ''));
+        if ($returnUrl !== '' && !str_starts_with($returnUrl, '/crons')) {
+            $returnUrl = '';
+        }
+
         $this->render('cron/form.php', $this->translator()->t('cron_add'), [
             'job'            => null,
             'tags'           => $tags,
@@ -206,6 +211,7 @@ class CronController extends BaseController
             'sshHostsByUser' => json_encode($sshHostsByUser, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'error'          => null,
             'isEdit'         => false,
+            'returnUrl'      => $returnUrl,
         ], '/crons');
     }
 
@@ -239,6 +245,11 @@ class CronController extends BaseController
 
             $sshHostsByUser = $this->fetchSshHostsByUser();
 
+            $postReturn = trim((string) ($_POST['_return'] ?? ''));
+            if ($postReturn !== '' && !str_starts_with($postReturn, '/crons')) {
+                $postReturn = '';
+            }
+
             $this->render('cron/form.php', $this->translator()->t('cron_add'), [
                 'job'            => $_POST,
                 'tags'           => $tags,
@@ -246,6 +257,7 @@ class CronController extends BaseController
                 'sshHostsByUser' => json_encode($sshHostsByUser, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 'error'          => $e->getMessage(),
                 'isEdit'         => false,
+                'returnUrl'      => $postReturn,
             ], '/crons');
             return;
         }
@@ -255,7 +267,10 @@ class CronController extends BaseController
             'schedule'   => $data['schedule']   ?? '',
         ]);
 
-        (new Response())->redirect('/crons');
+        $returnUrl = trim((string) ($_POST['_return'] ?? ''));
+        $safe      = ($returnUrl !== '' && str_starts_with($returnUrl, '/crons')) ? $returnUrl : '/crons';
+
+        (new Response())->redirect($safe);
     }
 
     /**
@@ -338,6 +353,14 @@ class CronController extends BaseController
             ? $job['targets']
             : ['local'];
 
+        // Capture the return URL (e.g. the cron list with active filters) so the
+        // form can redirect back to it after a successful save instead of to /crons/{id}.
+        $returnUrl = trim((string) ($_GET['_return'] ?? ''));
+        // Validate: must be a relative /crons URL to prevent open redirects
+        if ($returnUrl !== '' && !str_starts_with($returnUrl, '/crons')) {
+            $returnUrl = '';
+        }
+
         $this->render('cron/form.php', $this->translator()->t('cron_edit'), [
             'job'             => $job,
             'tags'            => $tags,
@@ -346,6 +369,7 @@ class CronController extends BaseController
             'sshHostsByUser'  => json_encode([], JSON_UNESCAPED_UNICODE),
             'error'           => null,
             'isEdit'          => true,
+            'returnUrl'       => $returnUrl,
         ], '/crons');
     }
 
@@ -392,6 +416,11 @@ class CronController extends BaseController
                 }
             }
 
+            $postReturn = trim((string) ($_POST['_return'] ?? ''));
+            if ($postReturn !== '' && !str_starts_with($postReturn, '/crons')) {
+                $postReturn = '';
+            }
+
             $this->render('cron/form.php', $this->translator()->t('cron_edit'), [
                 'job'            => $mergedJob,
                 'tags'           => $tags,
@@ -399,13 +428,19 @@ class CronController extends BaseController
                 'sshHostsByUser' => json_encode([], JSON_UNESCAPED_UNICODE),
                 'error'          => $e->getMessage(),
                 'isEdit'         => true,
+                'returnUrl'      => $postReturn,
             ], '/crons');
             return;
         }
 
         $this->logger->info('CronController::update: job updated', ['id' => $id]);
 
-        (new Response())->redirect('/crons/' . rawurlencode($id));
+        // Redirect back to the list page (preserving any active filters) if a
+        // validated return URL was passed through the form, otherwise show detail.
+        $returnUrl = trim((string) ($_POST['_return'] ?? ''));
+        $safe      = ($returnUrl !== '' && str_starts_with($returnUrl, '/crons')) ? $returnUrl : '/crons/' . rawurlencode($id);
+
+        (new Response())->redirect($safe);
     }
 
     /**
@@ -565,14 +600,16 @@ class CronController extends BaseController
             'errors'   => $errorOccurred,
         ]);
 
-        // Store a flash success message with the count of imported jobs
+        // Store a flash message with the import result count
         SessionManager::set('_flash_success', str_replace(
             '{count}',
             (string) $imported,
             $this->translator()->t('import_success')
         ));
 
-        (new Response())->redirect('/crons');
+        // Redirect back to the import page for the same user so the success
+        // message is visible immediately and additional entries can be imported.
+        (new Response())->redirect('/crons/import?user=' . rawurlencode($user));
     }
 
     /**

--- a/web/src/Controller/ExportController.php
+++ b/web/src/Controller/ExportController.php
@@ -47,7 +47,7 @@ class ExportController extends BaseController
         $agent = $this->agentClient();
 
         try {
-            $tags    = $agent->get('/tags')['data']  ?? [];
+            $allTags = $agent->get('/tags')['data']  ?? [];
             $allJobs = $agent->get('/crons')['data'] ?? [];
         } catch (\RuntimeException $e) {
             $this->logger->error('ExportController::index: agent request failed', [
@@ -66,6 +66,12 @@ class ExportController extends BaseController
             }
         }
         sort($users);
+
+        // Only show tags that are in use (job_count > 0)
+        $tags = array_values(array_filter(
+            $allTags,
+            static fn(array $t): bool => ($t['job_count'] ?? 0) > 0
+        ));
 
         $this->render('export.php', $this->translator()->t('export_title'), [
             'tags'  => $tags,

--- a/web/src/Controller/SwimlaneController.php
+++ b/web/src/Controller/SwimlaneController.php
@@ -126,7 +126,12 @@ class SwimlaneController extends BaseController
 
         // Normalise agent responses (may return {data:[...]} or plain array)
         $rawJobs = $jobsResponse['data'] ?? $jobsResponse;
-        $tags    = $tagsResponse['data']  ?? $tagsResponse;
+        $allTags = $tagsResponse['data']  ?? $tagsResponse;
+
+        // Only expose tags that are currently assigned to at least one job
+        $tags = is_array($allTags)
+            ? array_values(array_filter($allTags, static fn(array $t): bool => ($t['job_count'] ?? 0) > 0))
+            : [];
 
         if (!is_array($rawJobs)) {
             $rawJobs = [];

--- a/web/src/Controller/TimelineController.php
+++ b/web/src/Controller/TimelineController.php
@@ -74,7 +74,7 @@ class TimelineController extends BaseController
         // ------------------------------------------------------------------
         try {
             $historyResponse = $agent->get('/history', $query);
-            $tags            = $agent->get('/tags')['data']  ?? [];
+            $allTags         = $agent->get('/tags')['data']  ?? [];
             $allJobs         = $agent->get('/crons')['data'] ?? [];
         } catch (\RuntimeException $e) {
             $this->logger->error('TimelineController::index: agent request failed', [
@@ -108,6 +108,12 @@ class TimelineController extends BaseController
             }
         }
         sort($users);
+
+        // Only show tags that are in use (job_count > 0)
+        $tags = array_values(array_filter(
+            $allTags,
+            static fn(array $t): bool => ($t['job_count'] ?? 0) > 0
+        ));
 
         // Active filter values passed to the template for pre-filling the form
         $filters = [

--- a/web/templates/cron/form.php
+++ b/web/templates/cron/form.php
@@ -28,6 +28,7 @@ $selectedTargets = isset($selectedTargets) && is_array($selectedTargets) ? $sele
 $sshHostsByUser  = isset($sshHostsByUser)  && is_string($sshHostsByUser) ? $sshHostsByUser  : '{}';
 $error           = isset($error)           && $error !== null            ? (string) $error  : null;
 $isEdit          = isset($isEdit)          && (bool) $isEdit;
+$returnUrl       = isset($returnUrl)       && is_string($returnUrl) ? $returnUrl : '';
 
 // Pre-fill form values from job data or from re-submitted POST data
 $val = static function (string $field, mixed $default = '') use ($job): string {
@@ -88,7 +89,10 @@ foreach ($tags as $tag) {
 
         <!-- Form -->
         <form method="POST" action="<?= htmlspecialchars($formAction, ENT_QUOTES, 'UTF-8') ?>" novalidate>
-            <input type="hidden" name="_csrf" value="<?= htmlspecialchars($csrf_token ?? '', ENT_QUOTES, 'UTF-8') ?>">
+            <input type="hidden" name="_csrf"   value="<?= htmlspecialchars($csrf_token ?? '', ENT_QUOTES, 'UTF-8') ?>">
+            <?php if ($returnUrl !== ''): ?>
+            <input type="hidden" name="_return" value="<?= htmlspecialchars($returnUrl, ENT_QUOTES, 'UTF-8') ?>">
+            <?php endif; ?>
 
             <!-- Linux User -->
             <div class="mb-4">

--- a/web/templates/cron/list.php
+++ b/web/templates/cron/list.php
@@ -77,7 +77,7 @@ $pageUrl = static function (int $targetPage) use ($filterTag, $filterUser, $filt
                 </svg>
                 <?= htmlspecialchars($t('import_title'), ENT_QUOTES, 'UTF-8') ?>
             </a>
-            <a href="/crons/new"
+            <a href="/crons/new?_return=<?= htmlspecialchars(rawurlencode($pageUrl($currentPage)), ENT_QUOTES, 'UTF-8') ?>"
                class="inline-flex items-center gap-1.5 bg-blue-600 hover:bg-blue-700 text-white
                       text-sm font-medium px-4 py-2.5 rounded-lg transition focus:outline-none
                       focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
@@ -383,7 +383,7 @@ $pageUrl = static function (int $targetPage) use ($filterTag, $filterUser, $filt
                             <?php if ($isAdmin): ?>
                                 <td class="px-4 py-3 text-sm">
                                     <div class="flex items-center gap-2">
-                                        <a href="/crons/<?= htmlspecialchars(rawurlencode($jobId), ENT_QUOTES, 'UTF-8') ?>/edit"
+                                        <a href="/crons/<?= htmlspecialchars(rawurlencode($jobId), ENT_QUOTES, 'UTF-8') ?>/edit?_return=<?= htmlspecialchars(rawurlencode($pageUrl($currentPage)), ENT_QUOTES, 'UTF-8') ?>"
                                            class="text-blue-600 hover:text-blue-800 text-sm font-medium transition">
                                             <?= htmlspecialchars($t('cron_edit'), ENT_QUOTES, 'UTF-8') ?>
                                         </a>

--- a/web/templates/dashboard.php
+++ b/web/templates/dashboard.php
@@ -41,7 +41,21 @@ $byUser        = (array) ($stats['byUser']      ?? []);
         <?= htmlspecialchars($t('dashboard_title'), ENT_QUOTES, 'UTF-8') ?>
     </h1>
     <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-        <?= htmlspecialchars(date('l, F j, Y'), ENT_QUOTES, 'UTF-8') ?>
+        <?php
+            // Build a locale-aware date string using translated day/month names.
+            // PHP's date('N') returns 1 (Mon) … 7 (Sun); date('n') returns 1–12.
+            $dayKeys  = ['day_monday','day_tuesday','day_wednesday','day_thursday',
+                         'day_friday','day_saturday','day_sunday'];
+            $dayName  = $translator->t($dayKeys[(int) date('N') - 1]);
+            $monthName = $translator->t('month_' . date('n'));
+            $dayNum   = (int) date('j');
+            $year     = date('Y');
+            $lang     = $translator->getLang();
+            $dateStr  = $lang === 'de'
+                ? "{$dayName}, {$dayNum}. {$monthName} {$year}"
+                : "{$dayName}, {$monthName} {$dayNum}, {$year}";
+        ?>
+        <?= htmlspecialchars($dateStr, ENT_QUOTES, 'UTF-8') ?>
     </p>
 </div>
 

--- a/web/templates/layout.php
+++ b/web/templates/layout.php
@@ -23,7 +23,12 @@ use Cronmanager\Web\Session\SessionManager;
 $title       = isset($title)       ? (string) $title       : 'Cronmanager';
 $content     = isset($content)     ? (string) $content     : '';
 $currentPath = isset($currentPath) ? (string) $currentPath : '/';
-$user        = isset($user)        ? (array)  $user        : SessionManager::getUser();
+
+// Always read the user directly from the session here.
+// Sub-templates can define a loop variable named $user (e.g. foreach ($users as $user))
+// which would contaminate the shared variable scope and cause the wrong role to display.
+// Using SessionManager::getUser() directly guarantees we always show the real session user.
+$user = SessionManager::getUser();
 
 /** @var Translator $translator */
 $t = static fn(string $key, array $r = []): string => isset($translator) ? $translator->t($key, $r) : $key;
@@ -34,7 +39,7 @@ $lang = isset($translator) ? $translator->getLang() : 'en';
 $otherLang  = $lang === 'de' ? 'en' : 'de';
 $langLabel  = $t('lang_switch');
 
-// Build role badge label and colour
+// Build role badge label and colour – always from the session user
 $roleLabel = '';
 $roleBadge = '';
 if ($user !== null) {

--- a/web/templates/swimlane.php
+++ b/web/templates/swimlane.php
@@ -400,6 +400,38 @@ $timings          = isset($timings)          ? (array)  $timings          : [];
 /** @type {Array} */
 const JOBS = <?= $swimlaneJobsJson ?>;
 
+/* ─── Translations injected from PHP ────────────────────────────────────── */
+const I18N = <?= json_encode([
+    'time_prefix'      => $translator->t('swimlane_time_prefix'),
+    'day_prefix'       => $translator->t('swimlane_day_prefix'),
+    'all_days'         => $translator->t('swimlane_all_days'),
+    'job_singular'     => $translator->t('swimlane_job_singular'),
+    'job_plural'       => $translator->t('swimlane_job_plural'),
+    'shown'            => $translator->t('swimlane_shown'),
+    'next_prefix'      => $translator->t('swimlane_next_prefix'),
+    'at'               => $translator->t('swimlane_at'),
+    'in_prefix'        => $translator->t('swimlane_in_prefix'),
+    'min'              => $translator->t('swimlane_min'),
+    'hour_abbr'        => $translator->t('swimlane_hour_abbr'),
+    'inactive_warning' => $translator->t('swimlane_inactive_warning'),
+    'sw_schedule'      => $translator->t('sw_schedule'),
+    'sw_meaning'       => $translator->t('sw_meaning'),
+    'sw_fires_at'      => $translator->t('sw_fires_at'),
+    'sw_target'        => $translator->t('sw_target'),
+    'sw_user'          => $translator->t('sw_user'),
+    'sw_tags'          => $translator->t('sw_tags'),
+    // Day names indexed as JS getDay() (0 = Sun … 6 = Sat)
+    'days' => [
+        $translator->t('day_sunday'),
+        $translator->t('day_monday'),
+        $translator->t('day_tuesday'),
+        $translator->t('day_wednesday'),
+        $translator->t('day_thursday'),
+        $translator->t('day_friday'),
+        $translator->t('day_saturday'),
+    ],
+], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE) ?>;
+
 /* ─── Colour palette for tags (assigned on first encounter) ─────────────── */
 const PALETTE = [
     '#0284c7', '#059669', '#7c3aed', '#b45309',
@@ -497,18 +529,16 @@ function buildNowLine() {
 }
 
 /* ─── Info bar ───────────────────────────────────────────────────────────── */
-const DAY_NAMES = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
-
 function updateInfoBar(visibleCount) {
     const endLabel = endH === 24 ? '24:00' : padH(endH);
     document.getElementById('lblRange').textContent =
-        'Time: ' + padH(startH) + ' – ' + endLabel;
+        I18N.time_prefix + ' ' + padH(startH) + ' – ' + endLabel;
 
     document.getElementById('lblDay').textContent =
-        'Day: ' + (selDay === -1 ? 'All days' : DAY_NAMES[selDay] + 's');
+        I18N.day_prefix + ' ' + (selDay === -1 ? I18N.all_days : I18N.days[selDay]);
 
     document.getElementById('lblCount').textContent =
-        visibleCount + ' job' + (visibleCount !== 1 ? 's' : '') + ' shown';
+        visibleCount + ' ' + (visibleCount !== 1 ? I18N.job_plural : I18N.job_singular) + ' ' + I18N.shown;
 
     // Find the next upcoming fire time today (within the selected range)
     const now = new Date();
@@ -530,8 +560,8 @@ function updateInfoBar(visibleCount) {
     if (nextJob) {
         const hh = Math.floor(nextMin / 60), mm = nextMin % 60;
         const diff = nextMin - curMin;
-        const diffStr = diff < 60 ? diff + ' min' : (diff / 60).toFixed(1) + ' h';
-        lblNext.textContent = 'Next: ' + nextJob + ' at ' + padT(hh, mm) + ' (in ' + diffStr + ')';
+        const diffStr = diff < 60 ? diff + ' ' + I18N.min : (diff / 60).toFixed(1) + ' ' + I18N.hour_abbr;
+        lblNext.textContent = I18N.next_prefix + ' ' + nextJob + ' ' + I18N.at + ' ' + padT(hh, mm) + ' (' + I18N.in_prefix + ' ' + diffStr + ')';
     } else {
         lblNext.textContent = '';
     }
@@ -716,13 +746,13 @@ function showTip(e) {
         '<div style="font-weight:700;font-size:.9rem;color:' + escHtml(d.color) + ';margin-bottom:6px">' +
             escHtml(d.job) +
         '</div>' +
-        row('Schedule', '<span style="color:#38bdf8;font-family:monospace">' + escHtml(d.cron) + '</span>') +
-        row('Meaning',  escHtml(d.cronHuman)) +
-        row('Fires at', '<strong>' + time + '</strong>') +
-        row('Target',   escHtml(d.target)) +
-        row('User',     escHtml(d.user)) +
-        (d.tags ? row('Tags', escHtml(d.tags)) : '') +
-        (!isActive ? '<div style="margin-top:6px;color:#f97316;font-size:.75rem">⚠ Job is inactive</div>' : '');
+        row(I18N.sw_schedule, '<span style="color:#38bdf8;font-family:monospace">' + escHtml(d.cron) + '</span>') +
+        row(I18N.sw_meaning,  escHtml(d.cronHuman)) +
+        row(I18N.sw_fires_at, '<strong>' + time + '</strong>') +
+        row(I18N.sw_target,   escHtml(d.target)) +
+        row(I18N.sw_user,     escHtml(d.user)) +
+        (d.tags ? row(I18N.sw_tags, escHtml(d.tags)) : '') +
+        (!isActive ? '<div style="margin-top:6px;color:#f97316;font-size:.75rem">' + escHtml(I18N.inactive_warning) + '</div>' : '');
 
     tip.classList.remove('hidden');
     moveTip(e);

--- a/web/templates/timeline.php
+++ b/web/templates/timeline.php
@@ -188,8 +188,11 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
      ====================================================================== -->
 <?php if ($total > 0): ?>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Showing <span class="font-medium"><?= $showFrom ?></span>–<span class="font-medium"><?= $showTo ?></span>
-        of <span class="font-medium"><?= $total ?></span> executions
+        <?= htmlspecialchars($t('timeline_showing', [
+            'from'  => (string) $showFrom,
+            'to'    => (string) $showTo,
+            'total' => (string) $total,
+        ]), ENT_QUOTES, 'UTF-8') ?>
     </p>
 <?php endif; ?>
 


### PR DESCRIPTION
1. Dashboard date shown in English regardless of language setting
  Date like "Thursday, March 19, 2026" was always in English. Fixed by replacing the unavailable IntlDateFormatter with manual translation using day/month name keys from the language files.

  2. Timeline "Showing X–Y of Z executions" hardcoded in English
  The pagination label was a hardcoded English string. Fixed with a translatable timeline_showing key with {from}, {to}, {total} placeholders.

  3. Swimlane info bar and tooltip strings hardcoded in English
  All JavaScript UI strings (time prefix, day names, job count labels, etc.) were hardcoded English. Fixed by injecting a translated I18N object from PHP into the JS.

  4. Tag filters showing unused tags (Timeline, Swimlane, Export)
  All three pages showed tags that had no jobs assigned. Fixed by filtering to only tags with job_count > 0.

  5. Role badge showing "Viewer" instead of "Administrator" for admin users
  layout.php used isset($user) ? (array) $user : SessionManager::getUser(). Templates using foreach ($users as $user) polluted the shared scope, leaving $user as a plain string. Fixed by always calling
  SessionManager::getUser() unconditionally.

  6. Filter not preserved after editing a cron job
  After saving an edit, the user was redirected to the unfiltered list. Fixed with a _return URL pattern: the current filtered list URL is encoded into the edit/add link, passed through the form as a hidden
  field, and used as the redirect target after save.

  7. Filter not preserved after adding a new cron job
  Same issue as #6, applied to the Add Job flow.

  8. Import success message not shown after redirect
  importStore() redirected to /crons (list page) after success, but the flash message was only rendered on the import template. Fixed by redirecting back to /crons/import?user=….

  9. Import fails with 422 for @monthly, @daily, etc. style schedules
  The agent's isValidCronSchedule() only accepted 5–6 numeric field expressions. Fixed by replacing the hand-rolled regex with dragonmantank/cron-expression, which properly validates all standard expressions
  including @ shorthands, named day abbreviations (sat, mon, …), and named month abbreviations (jan, feb, …). @reboot is handled as a special case since it is not a time expression and is not supported by the  library.