### PR TITLE
Add timeline target filter, page size selector, and persistent filter…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased] – branch: `filter_improve`
+
+### Added
+
+- **Timeline: target filter** – New "Execution Target" dropdown on the timeline filter bar. Filters execution history by the target the job ran on (e.g. `local` or SSH host). Only shown when more than one unique target exists. Backed by `el.target = :target` in `HistoryEndpoint`.
+- **Timeline: configurable page size** – Replaced the hidden `limit` input with a visible page size selector offering 10 / 25 / 50 / 100 / 500 entries per page. Selection is persisted via cookie.
+- **Timeline: target column in results table** – Each history row now shows the execution target as a badge.
+- **Timeline: reset filters link** – A "×" link appears when any filter is active; it navigates to `?_reset=1` which clears all stored filter cookies.
+- **Persistent filter cookies (crons, timeline)** – All filter selections (tag, user, target, search, page size) are stored in 30-day cookies (`cronmgr_crons_*`, `cronmgr_tl_*`). On page load the cookie values are used as defaults when no GET parameters are present, so filter state survives navigation. Browsers that block cookies fall back to the previous stateless behaviour.
+- **Persistent filter cookies (swimlane)** – All swimlane filter controls (from/to hour, day of week, tag, target) are persisted in 30-day cookies (`cronmgr_sl_*`) via JavaScript. A "×" reset button clears all swimlane cookies and resets the controls to their defaults.
+- **`BaseController::filterParam()`** – New protected helper that resolves a filter value from GET → cookie fallback, writes the result back to the cookie, and handles `?_reset=1` to expire cookies.
+
+### Changed
+
+- **Crons list: reset filters link** – The "×" clear-filters link now navigates to `/crons?_reset=1` instead of bare `/crons`, so stored filter cookies are properly cleared.
+
+---
+
 ## [Unreleased] – branch: `small_fix`
 
 ### Fixed

--- a/agent/src/Endpoints/HistoryEndpoint.php
+++ b/agent/src/Endpoints/HistoryEndpoint.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
  *   - offset  (int, ≥ 0)       Pagination offset (default 0).
  *   - from    (YYYY-MM-DD)     Only executions started on or after this date.
  *   - to      (YYYY-MM-DD)     Only executions started on or before this date.
+ *   - target  (string)         Filter by execution target (e.g. "local" or SSH host alias).
  *
  * This class relies on the global `jsonResponse()` function being available
  * in the calling scope (defined in agent.php).
@@ -116,8 +117,9 @@ final class HistoryEndpoint
         // ------------------------------------------------------------------
 
         $jobId  = $this->parsePositiveInt($_GET['job_id'] ?? null);
-        $tag    = isset($_GET['tag'])  && $_GET['tag']  !== '' ? (string) $_GET['tag']  : null;
-        $user   = isset($_GET['user']) && $_GET['user'] !== '' ? (string) $_GET['user'] : null;
+        $tag    = isset($_GET['tag'])    && $_GET['tag']    !== '' ? (string) $_GET['tag']    : null;
+        $user   = isset($_GET['user'])   && $_GET['user']   !== '' ? (string) $_GET['user']   : null;
+        $target = isset($_GET['target']) && $_GET['target'] !== '' ? (string) $_GET['target'] : null;
         $status = isset($_GET['status']) && $_GET['status'] !== '' ? (string) $_GET['status'] : null;
         $limit  = $this->parseLimit($_GET['limit']   ?? null);
         $offset = $this->parseOffset($_GET['offset'] ?? null);
@@ -171,6 +173,11 @@ final class HistoryEndpoint
         if ($user !== null) {
             $conditions[]           = 'j.linux_user = :user';
             $queryParams[':user']   = $user;
+        }
+
+        if ($target !== null) {
+            $conditions[]             = 'el.target = :target';
+            $queryParams[':target']   = $target;
         }
 
         if ($tag !== null) {

--- a/web/src/Controller/BaseController.php
+++ b/web/src/Controller/BaseController.php
@@ -175,6 +175,54 @@ abstract class BaseController
         ], $currentPath);
     }
 
+    /**
+     * Resolve a filter parameter from GET, falling back to a persistent cookie.
+     *
+     * Resolution order:
+     *   1. If ?_reset is present in the request, expire the cookie and return $default.
+     *   2. If the named GET key is present, use its value (even empty) and save to cookie.
+     *   3. Otherwise fall back to the stored cookie value, or $default when absent.
+     *
+     * setcookie() silently fails when the browser blocks cookies, degrading
+     * gracefully to the previous stateless behaviour.
+     *
+     * @param string $get     Name of the GET query parameter.
+     * @param string $cookie  Cookie name to read from / write to.
+     * @param string $default Value returned when absent from both GET and cookie.
+     *
+     * @return string Resolved, trimmed filter value.
+     */
+    protected function filterParam(string $get, string $cookie, string $default = ''): string
+    {
+        // User clicked "reset filters" – clear the cookie and return the default.
+        if (isset($_GET['_reset'])) {
+            setcookie($cookie, '', [
+                'expires'  => time() - 1,
+                'path'     => '/',
+                'samesite' => 'Lax',
+                'httponly' => true,
+            ]);
+            return $default;
+        }
+
+        // Explicit GET value (including empty string) takes precedence over cookie.
+        if (array_key_exists($get, $_GET)) {
+            $value = trim((string) $_GET[$get]);
+        } else {
+            $value = isset($_COOKIE[$cookie]) ? (string) $_COOKIE[$cookie] : $default;
+        }
+
+        // Persist the resolved value for the next page load.
+        setcookie($cookie, $value, [
+            'expires'  => time() + 30 * 24 * 3600,
+            'path'     => '/',
+            'samesite' => 'Lax',
+            'httponly' => true,
+        ]);
+
+        return $value;
+    }
+
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------

--- a/web/src/Controller/CronController.php
+++ b/web/src/Controller/CronController.php
@@ -56,11 +56,14 @@ class CronController extends BaseController
      */
     public function index(array $params): void
     {
-        $agent         = $this->agentClient();
-        $filterTag    = trim((string) ($_GET['tag']    ?? ''));
-        $filterUser   = trim((string) ($_GET['user']   ?? ''));
-        $filterTarget = trim((string) ($_GET['target'] ?? ''));
-        $filterSearch = trim((string) ($_GET['search'] ?? ''));
+        $agent = $this->agentClient();
+
+        // filterParam() reads from GET first, falls back to a persistent cookie,
+        // and saves the resolved value back to the cookie for next time.
+        $filterTag    = $this->filterParam('tag',    'cronmgr_crons_tag');
+        $filterUser   = $this->filterParam('user',   'cronmgr_crons_user');
+        $filterTarget = $this->filterParam('target', 'cronmgr_crons_target');
+        $filterSearch = $this->filterParam('search', 'cronmgr_crons_search');
 
         // ------------------------------------------------------------------
         // Resolve page-size preference

--- a/web/src/Controller/TimelineController.php
+++ b/web/src/Controller/TimelineController.php
@@ -36,11 +36,13 @@ class TimelineController extends BaseController
      * Supported GET parameters:
      *   ?tag=     – filter by tag name
      *   ?user=    – filter by linux_user
+     *   ?target=  – filter by execution target
      *   ?status=  – filter by execution status (success | failed | running)
      *   ?from=    – filter from date (YYYY-MM-DD)
      *   ?to=      – filter to date (YYYY-MM-DD)
-     *   ?limit=   – number of results per page (default: 50)
+     *   ?limit=   – number of results per page (10 | 25 | 50 | 100 | 500, default: 50)
      *   ?offset=  – pagination offset (default: 0)
+     *   ?_reset=1 – clear all stored filter cookies and reset to defaults
      *
      * @param array<string,string> $params Path parameters (unused).
      *
@@ -51,20 +53,30 @@ class TimelineController extends BaseController
         $agent = $this->agentClient();
 
         // ------------------------------------------------------------------
-        // Read and sanitise filter / pagination parameters from the request
+        // Read and sanitise filter / pagination parameters.
+        // filterParam() reads from GET first, falls back to a persistent cookie,
+        // and saves the resolved value back to the cookie for next time.
         // ------------------------------------------------------------------
-        $filterTag    = trim((string) ($_GET['tag']    ?? ''));
-        $filterUser   = trim((string) ($_GET['user']   ?? ''));
-        $filterStatus = trim((string) ($_GET['status'] ?? ''));
-        $filterFrom   = trim((string) ($_GET['from']   ?? ''));
-        $filterTo     = trim((string) ($_GET['to']     ?? ''));
-        $limit        = max(1, (int) ($_GET['limit']  ?? 50));
-        $offset       = max(0, (int) ($_GET['offset'] ?? 0));
+        $filterTag    = $this->filterParam('tag',    'cronmgr_tl_tag');
+        $filterUser   = $this->filterParam('user',   'cronmgr_tl_user');
+        $filterTarget = $this->filterParam('target', 'cronmgr_tl_target');
+        $filterStatus = $this->filterParam('status', 'cronmgr_tl_status');
+        $filterFrom   = $this->filterParam('from',   'cronmgr_tl_from');
+        $filterTo     = $this->filterParam('to',     'cronmgr_tl_to');
+
+        // Page size: validate against the allowed set; persist via cookie.
+        $allowedLimits = [10, 25, 50, 100, 500];
+        $limitRaw      = (int) $this->filterParam('limit', 'cronmgr_tl_limit', '50');
+        $limit         = in_array($limitRaw, $allowedLimits, strict: true) ? $limitRaw : 50;
+
+        // Offset is pure pagination state – never stored in a cookie.
+        $offset = max(0, (int) ($_GET['offset'] ?? 0));
 
         // Build agent query params – only include non-empty filters
         $query = ['limit' => $limit, 'offset' => $offset];
         if ($filterTag    !== '') { $query['tag']    = $filterTag; }
         if ($filterUser   !== '') { $query['user']   = $filterUser; }
+        if ($filterTarget !== '') { $query['target'] = $filterTarget; }
         if ($filterStatus !== '') { $query['status'] = $filterStatus; }
         if ($filterFrom   !== '') { $query['from']   = $filterFrom; }
         if ($filterTo     !== '') { $query['to']     = $filterTo; }
@@ -98,16 +110,24 @@ class TimelineController extends BaseController
         }
 
         // ------------------------------------------------------------------
-        // Build unique user list from all jobs (for filter dropdown)
+        // Build unique user and target lists from all jobs (for filter dropdowns)
         // ------------------------------------------------------------------
-        $users = [];
+        $users      = [];
+        $allTargets = [];
         foreach ($allJobs as $job) {
             $u = (string) ($job['linux_user'] ?? '');
             if ($u !== '' && !in_array($u, $users, strict: true)) {
                 $users[] = $u;
             }
+            foreach ((array) ($job['targets'] ?? []) as $tgt) {
+                $tgt = (string) $tgt;
+                if ($tgt !== '' && !in_array($tgt, $allTargets, strict: true)) {
+                    $allTargets[] = $tgt;
+                }
+            }
         }
         sort($users);
+        sort($allTargets);
 
         // Only show tags that are in use (job_count > 0)
         $tags = array_values(array_filter(
@@ -119,6 +139,7 @@ class TimelineController extends BaseController
         $filters = [
             'tag'    => $filterTag,
             'user'   => $filterUser,
+            'target' => $filterTarget,
             'status' => $filterStatus,
             'from'   => $filterFrom,
             'to'     => $filterTo,
@@ -128,13 +149,14 @@ class TimelineController extends BaseController
         // Render
         // ------------------------------------------------------------------
         $this->render('timeline.php', $this->translator()->t('timeline_title'), [
-            'history' => $history,
-            'tags'    => $tags,
-            'users'   => $users,
-            'total'   => $total,
-            'limit'   => $limit,
-            'offset'  => $offset,
-            'filters' => $filters,
+            'history'    => $history,
+            'tags'       => $tags,
+            'users'      => $users,
+            'allTargets' => $allTargets,
+            'total'      => $total,
+            'limit'      => $limit,
+            'offset'     => $offset,
+            'filters'    => $filters,
         ], '/timeline');
     }
 }

--- a/web/templates/cron/list.php
+++ b/web/templates/cron/list.php
@@ -212,7 +212,7 @@ $pageUrl = static function (int $targetPage) use ($filterTag, $filterUser, $filt
 
         <?php if ($filterTag !== '' || $filterUser !== '' || $filterTarget !== '' || $filterSearch !== ''): ?>
             <div>
-                <a href="/crons"
+                <a href="/crons?_reset=1"
                    class="text-sm text-gray-500 hover:text-gray-700 underline py-2 block">
                     &times; <?= htmlspecialchars($t('cancel'), ENT_QUOTES, 'UTF-8') ?>
                 </a>

--- a/web/templates/swimlane.php
+++ b/web/templates/swimlane.php
@@ -340,6 +340,14 @@ $timings          = isset($timings)          ? (array)  $timings          : [];
         </select>
     </div>
     <?php endif; ?>
+
+    <!-- Reset all filters -->
+    <div class="ml-auto">
+        <button type="button" id="btnResetFilters"
+                class="text-sm text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 underline">
+            &times; <?= $t('cancel') ?>
+        </button>
+    </div>
 </div>
 
 <!-- ── Swimlane card ──────────────────────────────────────────────────────── -->
@@ -431,6 +439,35 @@ const I18N = <?= json_encode([
         $translator->t('day_saturday'),
     ],
 ], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE) ?>;
+
+/* ─── Cookie helpers ─────────────────────────────────────────────────────── */
+/**
+ * Read a cookie value by name. Returns null when absent or when the browser
+ * does not expose document.cookie (e.g. strict blocking).
+ * @param {string} name
+ * @returns {string|null}
+ */
+function getCookie(name) {
+    try {
+        const match = document.cookie.match(
+            new RegExp('(?:^|; )' + name.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1') + '=([^;]*)')
+        );
+        return match ? decodeURIComponent(match[1]) : null;
+    } catch (_) { return null; }
+}
+
+/**
+ * Persist a cookie for 30 days. Silently fails when the browser blocks cookies.
+ * @param {string} name
+ * @param {string} value
+ */
+function setCookie(name, value) {
+    try {
+        const exp = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toUTCString();
+        document.cookie = name + '=' + encodeURIComponent(value)
+            + '; expires=' + exp + '; path=/; SameSite=Lax';
+    } catch (_) { /* cookies blocked – degrade gracefully */ }
+}
 
 /* ─── Colour palette for tags (assigned on first encounter) ─────────────── */
 const PALETTE = [
@@ -795,25 +832,99 @@ function buildHourSelects() {
     ss.addEventListener('change', () => {
         startH = Number(ss.value);
         if (endH <= startH) { endH = Math.min(24, startH + 1); es.value = endH; }
+        setCookie('cronmgr_sl_start', String(startH));
+        setCookie('cronmgr_sl_end',   String(endH));
         render();
     });
     es.addEventListener('change', () => {
         endH = Number(es.value);
         if (startH >= endH) { startH = Math.max(0, endH - 1); ss.value = startH; }
+        setCookie('cronmgr_sl_start', String(startH));
+        setCookie('cronmgr_sl_end',   String(endH));
         render();
     });
 }
 
+/* ─── Cookie-backed state restore ────────────────────────────────────────── */
+/**
+ * After the hour selects have been built, restore all filter values from
+ * cookies (if present). State variables (startH, endH, selDay) are updated
+ * to match so the first render() call reflects the restored state.
+ */
+function restoreFromCookies() {
+    const ss = document.getElementById('selStart');
+    const es = document.getElementById('selEnd');
+
+    const savedStart = getCookie('cronmgr_sl_start');
+    const savedEnd   = getCookie('cronmgr_sl_end');
+    const savedDay   = getCookie('cronmgr_sl_day');
+    const savedTag   = getCookie('cronmgr_sl_tag');
+    const savedTgt   = getCookie('cronmgr_sl_target');
+
+    if (savedStart !== null) {
+        const v = Math.max(0, Math.min(23, Number(savedStart)));
+        if (!isNaN(v)) { startH = v; ss.value = v; }
+    }
+    if (savedEnd !== null) {
+        const v = Math.max(1, Math.min(24, Number(savedEnd)));
+        if (!isNaN(v) && v > startH) { endH = v; es.value = v; }
+    }
+    if (savedDay !== null) {
+        const v = Number(savedDay);
+        if (!isNaN(v) && v >= -1 && v <= 6) {
+            selDay = v;
+            document.getElementById('selDay').value = v;
+        }
+    }
+    if (savedTag !== null) {
+        const el = document.getElementById('selTag');
+        if ([...el.options].some(o => o.value === savedTag)) el.value = savedTag;
+    }
+    const selTargetEl = document.getElementById('selTarget');
+    if (selTargetEl && savedTgt !== null) {
+        if ([...selTargetEl.options].some(o => o.value === savedTgt)) selTargetEl.value = savedTgt;
+    }
+}
+
 /* ─── Init ───────────────────────────────────────────────────────────────── */
 buildHourSelects();
+restoreFromCookies();
 render();
 
 document.getElementById('selDay').addEventListener('change', e => {
-    selDay = Number(e.target.value); render();
+    selDay = Number(e.target.value);
+    setCookie('cronmgr_sl_day', String(selDay));
+    render();
 });
-document.getElementById('selTag').addEventListener('change', render);
+document.getElementById('selTag').addEventListener('change', e => {
+    setCookie('cronmgr_sl_tag', e.target.value);
+    render();
+});
 const selTarget = document.getElementById('selTarget');
-if (selTarget) selTarget.addEventListener('change', render);
+if (selTarget) {
+    selTarget.addEventListener('change', e => {
+        setCookie('cronmgr_sl_target', e.target.value);
+        render();
+    });
+}
+
+// Reset button – clears all swimlane filter cookies and resets controls
+document.getElementById('btnResetFilters').addEventListener('click', () => {
+    const ss = document.getElementById('selStart');
+    const es = document.getElementById('selEnd');
+
+    startH = 0; endH = 24; selDay = -1;
+    ss.value = 0; es.value = 24;
+    document.getElementById('selDay').value = -1;
+    document.getElementById('selTag').value = '';
+    const selTargetEl = document.getElementById('selTarget');
+    if (selTargetEl) selTargetEl.value = '';
+
+    ['cronmgr_sl_start','cronmgr_sl_end','cronmgr_sl_day',
+     'cronmgr_sl_tag','cronmgr_sl_target'].forEach(n => setCookie(n, ''));
+
+    render();
+});
 
 // Re-render when dark mode is toggled so grid/axis colours update
 const origToggle = window.toggleDarkMode;

--- a/web/templates/timeline.php
+++ b/web/templates/timeline.php
@@ -8,13 +8,14 @@ declare(strict_types=1);
  * Displays a paginated, filterable execution history across all jobs.
  *
  * Variables available in this template:
- *   array  $history – execution history records from the agent
- *   array  $tags    – all known tags (for filter dropdown)
- *   array  $users   – unique linux_users (for filter dropdown)
- *   int    $total   – total number of matching records (for pagination)
- *   int    $limit   – records per page
- *   int    $offset  – current page offset
- *   array  $filters – active filter values: tag, user, status, from, to
+ *   array  $history    – execution history records from the agent
+ *   array  $tags       – all known tags (for filter dropdown)
+ *   array  $users      – unique linux_users (for filter dropdown)
+ *   array  $allTargets – unique execution targets (for filter dropdown)
+ *   int    $total      – total number of matching records (for pagination)
+ *   int    $limit      – records per page
+ *   int    $offset     – current page offset
+ *   array  $filters    – active filter values: tag, user, target, status, from, to
  *
  * @author  Christian Schulz <technik@meinetechnikwelt.rocks>
  * @license GNU General Public License version 3 or later
@@ -23,19 +24,24 @@ declare(strict_types=1);
 /** @var \Cronmanager\Web\I18n\Translator $translator */
 $t = fn(string $k, array $r = []): string => $translator->t($k, $r);
 
-$history = isset($history) && is_array($history) ? $history : [];
-$tags    = isset($tags)    && is_array($tags)    ? $tags    : [];
-$users   = isset($users)   && is_array($users)   ? $users   : [];
-$total   = isset($total)   ? (int) $total   : 0;
-$limit   = isset($limit)   ? max(1, (int) $limit)  : 50;
-$offset  = isset($offset)  ? max(0, (int) $offset) : 0;
-$filters = isset($filters) && is_array($filters) ? $filters : [];
+$history    = isset($history)    && is_array($history)    ? $history    : [];
+$tags       = isset($tags)       && is_array($tags)       ? $tags       : [];
+$users      = isset($users)      && is_array($users)      ? $users      : [];
+$allTargets = isset($allTargets) && is_array($allTargets) ? $allTargets : [];
+$total      = isset($total)  ? (int) $total              : 0;
+$limit      = isset($limit)  ? max(1, (int) $limit)      : 50;
+$offset     = isset($offset) ? max(0, (int) $offset)     : 0;
+$filters    = isset($filters) && is_array($filters) ? $filters : [];
 
 $activeStatus = (string) ($filters['status'] ?? '');
 $activeTag    = (string) ($filters['tag']    ?? '');
 $activeUser   = (string) ($filters['user']   ?? '');
+$activeTarget = (string) ($filters['target'] ?? '');
 $activeFrom   = (string) ($filters['from']   ?? '');
 $activeTo     = (string) ($filters['to']     ?? '');
+
+$hasActiveFilter = $activeTag !== '' || $activeUser !== '' || $activeTarget !== ''
+    || $activeStatus !== '' || $activeFrom !== '' || $activeTo !== '';
 
 // Pagination helpers
 $prevOffset  = max(0, $offset - $limit);
@@ -54,6 +60,7 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
     $params = array_filter([
         'tag'    => $filters['tag']    ?? '',
         'user'   => $filters['user']   ?? '',
+        'target' => $filters['target'] ?? '',
         'status' => $filters['status'] ?? '',
         'from'   => $filters['from']   ?? '',
         'to'     => $filters['to']     ?? '',
@@ -143,6 +150,27 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
             </select>
         </div>
 
+        <!-- Target filter (shown only when more than one unique target exists) -->
+        <?php if (count($allTargets) > 1): ?>
+        <div class="flex-1 min-w-32">
+            <label for="filter-target" class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                <?= htmlspecialchars($t('cron_targets'), ENT_QUOTES, 'UTF-8') ?>
+            </label>
+            <select id="filter-target" name="target"
+                    class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm
+                           bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                           focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value=""><?= htmlspecialchars($t('filter_all_targets'), ENT_QUOTES, 'UTF-8') ?></option>
+                <?php foreach ($allTargets as $tgt): ?>
+                    <?php $sel = $activeTarget === $tgt ? ' selected' : ''; ?>
+                    <option value="<?= htmlspecialchars($tgt, ENT_QUOTES, 'UTF-8') ?>"<?= $sel ?>>
+                        <?= htmlspecialchars($tgt, ENT_QUOTES, 'UTF-8') ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <?php endif; ?>
+
         <!-- From date -->
         <div class="flex-1 min-w-32">
             <label for="filter-from" class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
@@ -167,8 +195,20 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
                           focus:outline-none focus:ring-2 focus:ring-blue-500">
         </div>
 
-        <!-- Hidden limit to preserve page size -->
-        <input type="hidden" name="limit" value="<?= htmlspecialchars((string) $limit, ENT_QUOTES, 'UTF-8') ?>">
+        <!-- Page size selector -->
+        <div class="flex-1 min-w-28">
+            <label for="filter-limit" class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                <?= htmlspecialchars($t('pagination_page_size'), ENT_QUOTES, 'UTF-8') ?>
+            </label>
+            <select id="filter-limit" name="limit"
+                    class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm
+                           bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                           focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <?php foreach ([10, 25, 50, 100, 500] as $sz): ?>
+                    <option value="<?= $sz ?>"<?= $limit === $sz ? ' selected' : '' ?>><?= $sz ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
 
         <!-- Apply -->
         <div>
@@ -179,6 +219,16 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
                 <?= htmlspecialchars($t('filter_apply'), ENT_QUOTES, 'UTF-8') ?>
             </button>
         </div>
+
+        <!-- Reset filters link -->
+        <?php if ($hasActiveFilter): ?>
+        <div>
+            <a href="/timeline?_reset=1"
+               class="text-sm text-gray-500 hover:text-gray-700 underline py-2 block">
+                &times; <?= htmlspecialchars($t('cancel'), ENT_QUOTES, 'UTF-8') ?>
+            </a>
+        </div>
+        <?php endif; ?>
 
     </form>
 </div>
@@ -223,6 +273,9 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
                             <?= htmlspecialchars($t('cron_tags'), ENT_QUOTES, 'UTF-8') ?>
                         </th>
                         <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                            <?= htmlspecialchars($t('cron_targets'), ENT_QUOTES, 'UTF-8') ?>
+                        </th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                             <?= htmlspecialchars($t('duration'), ENT_QUOTES, 'UTF-8') ?>
                         </th>
                         <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
@@ -245,7 +298,8 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
                             $duration   = isset($entry['duration_seconds'])
                                 ? round((float) $entry['duration_seconds'], 1) . 's'
                                 : '–';
-                            $output     = (string) ($entry['output'] ?? '');
+                            $entryTarget = (string) ($entry['target'] ?? '');
+                            $output      = (string) ($entry['output'] ?? '');
                             $outputTrunc = mb_strlen($output) > 120
                                 ? mb_substr($output, 0, 120) . '…'
                                 : $output;
@@ -293,6 +347,15 @@ $pageUrl = static function (int $newOffset) use ($filters, $limit): string {
                                         </span>
                                     <?php endforeach; ?>
                                 </div>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                                <?php if ($entryTarget !== ''): ?>
+                                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                                        <?= htmlspecialchars($entryTarget, ENT_QUOTES, 'UTF-8') ?>
+                                    </span>
+                                <?php else: ?>
+                                    <span class="text-gray-300 dark:text-gray-600">—</span>
+                                <?php endif; ?>
                             </td>
                             <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
                                 <?= htmlspecialchars($duration, ENT_QUOTES, 'UTF-8') ?>


### PR DESCRIPTION
… cookies

- Timeline: add target filter dropdown backed by HistoryEndpoint el.target query
- Timeline: replace hidden limit input with visible page size selector (10/25/50/100/500)
- Timeline: add target column to execution history table
- Timeline: add reset-filters link (?_reset=1)
- BaseController: add filterParam() helper (GET → cookie fallback, 30-day persistence)
- CronController: use filterParam() for all filter params (tag, user, target, search)
- TimelineController: use filterParam() for all filters and limit
- cron/list.php: reset-filters link now uses ?_reset=1 to clear cookies
- swimlane.php: JS cookie helpers + restoreFromCookies() on init + save on change + reset button