### PR TITLE
Fix mb_strlen/mb_substr namespace resolution in MailNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased] – branch: `notify_fix`
+
+### Fixed
+
+- **`mb_strlen` / `mb_substr` namespace error in `MailNotifier`** – When a job failed with `notify_on_failure` enabled and mail was active, the agent logged `Call to undefined function Cronmanager\Agent\Notification\mb_strlen()`. PHP resolves unqualified function calls in the current namespace first; since no such function exists there, the call failed. Fixed by prefixing both calls with `\` (`\mb_strlen`, `\mb_substr`) to force resolution in the global namespace.
+
+---
+
 ## [Unreleased] – branch: `copy`
 
 ### Added

--- a/agent/src/Notification/MailNotifier.php
+++ b/agent/src/Notification/MailNotifier.php
@@ -120,8 +120,8 @@ final class MailNotifier
         // ------------------------------------------------------------------
 
         // Truncate output to 10 000 characters to keep the mail readable
-        $truncatedOutput = mb_strlen($output) > 10000
-            ? mb_substr($output, 0, 10000) . "\n\n[... output truncated to 10 000 characters ...]"
+        $truncatedOutput = \mb_strlen($output) > 10000
+            ? \mb_substr($output, 0, 10000) . "\n\n[... output truncated to 10 000 characters ...]"
             : $output;
 
         $subject = sprintf(


### PR DESCRIPTION
Unqualified mb_strlen() and mb_substr() calls inside the Cronmanager\Agent\Notification namespace caused a fatal "Call to undefined function" error whenever a failure alert was triggered. Prefixed both calls with \ to force global namespace resolution.