### PR TITLE
simple_debian_setup.sh: patch all agent files, not just explicit list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased] – branch: `pathfix`
+
+### Fixed
+
+- **Agent config path not found after installation** – Path patching only replaced hardcoded `/opt/phpscripts/cronmanager/agent` in a small explicit list of files (`agent.php`, `bin/*`). Files under `src/` (e.g. `src/Database/Connection.php`, `src/Bootstrap.php`) and SQL migrations were skipped, so the agent still referenced the old default path at runtime. Fixed by replacing the explicit file list with a `find` across all `*.php`, `*.sh`, and `*.sql` files in the agent directory.
+
+---
+
 ## [Unreleased] – branch: `monitor_filter`
 
 ### Added

--- a/simple_debian_setup.sh
+++ b/simple_debian_setup.sh
@@ -635,22 +635,13 @@ target_copy "$CLONE_DIR/agent/" "$AGENT_DIR/" \
     || warn_continue "Failed to copy agent files to ${AGENT_DIR}."
 ok "Agent files deployed."
 
-step "Patching hardcoded paths in agent scripts..."
-for _file in \
-    "${AGENT_DIR}/bin/start-agent.sh" \
-    "${AGENT_DIR}/bin/cron-wrapper.sh" \
-    "${AGENT_DIR}/bin/send-notification.php" \
-    "${AGENT_DIR}/bin/create-admin.php" \
-    "${AGENT_DIR}/agent.php"; do
-    target_exec "
-        test -f '$_file' || exit 0
-        sed -i \
-            -e 's|/opt/phpscripts/cronmanager/agent|${AGENT_DIR}|g' \
-            -e 's|/opt/phplib|${PHPLIB_DIR}|g' \
-            '$_file'
-        chmod +x '$_file' 2>/dev/null || true
-    " || warn_continue "Failed to patch paths in: $_file"
-done
+step "Patching hardcoded paths in all agent files..."
+target_exec "find '${AGENT_DIR}' \( -name '*.php' -o -name '*.sh' -o -name '*.sql' \) \
+    -exec sed -i \
+        -e 's|/opt/phpscripts/cronmanager/agent|${AGENT_DIR}|g' \
+        -e 's|/opt/phplib|${PHPLIB_DIR}|g' \
+    {} \;" || warn_continue "Failed to patch hardcoded paths in agent files."
+target_exec "chmod +x '${AGENT_DIR}/bin/'*.sh 2>/dev/null || true"
 ok "Paths patched."
 
 # Write agent config.json – generated locally via Python, written to target


### PR DESCRIPTION
Path replacement only covered agent.php and bin/* files, missing src/Database/Connection.php, src/Bootstrap.php, and SQL migrations which still referenced the old /opt/phpscripts/cronmanager/agent default path, causing a config-not-found RuntimeException on startup.

Replaced the explicit file loop with a find over all *.php, *.sh, and *.sql files under the agent directory.