### PR TITLE
feat: add Run Now button to execute cron jobs immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased] – branch: `execute_now`
+
+### Added
+
+- **Run Now button on cron list** – Each job row has a new "Run" button (yellow, next to Delete). Clicking it shows a confirmation dialog and then immediately schedules the job for execution at the next clock minute without leaving the current list page (filter state is preserved via `_return`).
+  - The button submits a `POST /crons/{id}/execute` form. The web controller forwards the request to the host agent and redirects back to the filtered list.
+  - The host agent `ExecuteNowEndpoint` builds a full-date one-time schedule (`{min} {hour} {dom} {month} *`) for the next minute and injects a `# cronmanager-once:{id}:{target}` + command line into the crontab of every configured target for the job. Using a full-date schedule means that a missed cleanup at most causes one spurious re-run per year (not once per hour).
+  - After the job finishes, `cron-wrapper.sh` detects the `--once` flag (third argument) and calls the new `POST /crons/{id}/execute/cleanup` agent endpoint, which removes the marker and command lines from the crontab. The cleanup call is fire-and-forget; a failure only means the entry expires naturally in at most one year.
+  - New agent endpoints: `ExecuteNowEndpoint` (`POST /crons/{id}/execute`) and `ExecuteCleanupEndpoint` (`POST /crons/{id}/execute/cleanup`).
+  - New `CrontabManager` methods: `addOnceEntry()` and `removeOnceEntries()`.
+  - New translation keys: `cron_run_now`, `cron_run_confirm` (EN + DE).
+
+---
+
 ## [Unreleased] – branch: `monitor_filter`
 
 ### Added

--- a/agent/agent.php
+++ b/agent/agent.php
@@ -182,11 +182,18 @@ try {
     $router->addRoute('GET',    '/crons/unmanaged',      [$cronUnmanaged, 'handle']);
     // /crons/{id}/monitor must be registered before /crons/{id} so the router
     // tries the more specific pattern first and does not mis-route the request.
-    $router->addRoute('GET',    '/crons/{id}/monitor',   [$cronMonitor,   'handle']);
-    $router->addRoute('GET',    '/crons/{id}',           [$cronGet,       'handle']);
-    $router->addRoute('POST',   '/crons',                [$cronCreate,    'handle']);
-    $router->addRoute('PUT',    '/crons/{id}',           [$cronUpdate,    'handle']);
-    $router->addRoute('DELETE', '/crons/{id}',           [$cronDelete,    'handle']);
+    $executeNow     = new \Cronmanager\Agent\Endpoints\ExecuteNowEndpoint($pdo, $logger, $crontabManager, $wrapperScript);
+    $executeCleanup = new \Cronmanager\Agent\Endpoints\ExecuteCleanupEndpoint($pdo, $logger, $crontabManager);
+
+    $router->addRoute('GET',    '/crons/{id}/monitor',          [$cronMonitor,   'handle']);
+    // /crons/{id}/execute/cleanup and /crons/{id}/execute must be registered
+    // before /crons/{id} so the more-specific patterns are tried first.
+    $router->addRoute('POST',   '/crons/{id}/execute/cleanup',  [$executeCleanup, 'handle']);
+    $router->addRoute('POST',   '/crons/{id}/execute',          [$executeNow,     'handle']);
+    $router->addRoute('GET',    '/crons/{id}',                  [$cronGet,       'handle']);
+    $router->addRoute('POST',   '/crons',                       [$cronCreate,    'handle']);
+    $router->addRoute('PUT',    '/crons/{id}',                  [$cronUpdate,    'handle']);
+    $router->addRoute('DELETE', '/crons/{id}',                  [$cronDelete,    'handle']);
 
     // -- Execution lifecycle --------------------------------------------------
 

--- a/agent/bin/cron-wrapper.sh
+++ b/agent/bin/cron-wrapper.sh
@@ -88,6 +88,12 @@ fi
 # When absent, the target is derived from the agent response (backward compat).
 TARGET="${2:-}"
 
+# Optional third argument: "--once" flag.
+# When present the wrapper was invoked from a once-only crontab entry created
+# by the Run Now feature.  After execution it calls the cleanup endpoint to
+# remove that temporary entry from the crontab.
+RUN_ONCE="${3:-}"
+
 # =============================================================================
 # Read configuration via PHP JSON parser
 # =============================================================================
@@ -410,6 +416,34 @@ elif [[ "$EXECUTION_ID" != "0" ]]; then
     fi
 else
     log_warn "Job ${JOB_ID}: skipping /execution/finish notification (no execution_id)"
+fi
+
+# =============================================================================
+# Step 5 (once-only): Remove the temporary crontab entry
+# =============================================================================
+#
+# When invoked with "--once" the job was scheduled via the Run Now feature.
+# Notify the agent cleanup endpoint so the temporary crontab entry is removed
+# immediately.  This is best-effort: if it fails the entry will fire at most
+# once per year due to its full-date schedule.
+
+if [[ "${RUN_ONCE}" == "--once" ]]; then
+    log_info "Job ${JOB_ID}: removing once-only crontab entry (target=${TARGET})"
+
+    CLEANUP_PATH="/crons/${JOB_ID}/execute/cleanup"
+    CLEANUP_BODY="$(php -r "
+        echo json_encode(['target' => '${TARGET}'], JSON_UNESCAPED_UNICODE);
+    ")"
+
+    if agent_request "POST" "${CLEANUP_PATH}" "${CLEANUP_BODY}" >/dev/null; then
+        if [[ "${_HTTP_CODE}" -ge 200 && "${_HTTP_CODE}" -lt 300 ]]; then
+            log_info "Job ${JOB_ID}: once-entry removed from crontab (http_code=${_HTTP_CODE})"
+        else
+            log_warn "Job ${JOB_ID}: cleanup returned HTTP ${_HTTP_CODE} – once-entry may remain in crontab (harmless, expires next year)"
+        fi
+    else
+        log_warn "Job ${JOB_ID}: could not reach agent for cleanup – once-entry may remain in crontab (harmless, expires next year)"
+    fi
 fi
 
 # =============================================================================

--- a/agent/src/Cron/CrontabManager.php
+++ b/agent/src/Cron/CrontabManager.php
@@ -49,6 +49,9 @@ final class CrontabManager
     /** @var string Prefix for the marker comment line written above each managed entry */
     private const MARKER_PREFIX = '# cronmanager:';
 
+    /** @var string Prefix for once-only marker comment lines (Run Now feature) */
+    private const ONCE_MARKER_PREFIX = '# cronmanager-once:';
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -586,6 +589,129 @@ final class CrontabManager
 
         // Matches legacy "# cronmanager:42" and new "# cronmanager:42:target"
         return str_contains($raw, $markerPrefix);
+    }
+
+    // -------------------------------------------------------------------------
+    // Once-only entry management (Run Now feature)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Add a once-only crontab entry that executes the job at the next minute.
+     *
+     * The entry uses a full-date schedule (minute, hour, day-of-month, month)
+     * so that even if cleanup fails after execution, the entry fires at most
+     * once per year rather than on every matching minute.
+     *
+     * Entry format written to the crontab:
+     *
+     *   # cronmanager-once:{jobId}:{target}
+     *   {schedule} {wrapperScript} {jobId} {target} --once
+     *
+     * The "--once" flag tells the wrapper script to call the cleanup endpoint
+     * after execution to remove this temporary entry.
+     *
+     * @param string $user          Linux user name.
+     * @param int    $jobId         Cronmanager job ID.
+     * @param string $schedule      Full-date cron expression, e.g. "37 14 26 3 *".
+     * @param string $wrapperScript Absolute path to the wrapper script.
+     * @param string $target        Execution target ('local' or SSH alias).
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When $user contains disallowed characters.
+     * @throws RuntimeException         When writing the crontab fails.
+     */
+    public function addOnceEntry(
+        string $user,
+        int    $jobId,
+        string $schedule,
+        string $wrapperScript,
+        string $target,
+    ): void {
+        $this->validateUser($user);
+
+        $existing = rtrim($this->readCrontab($user));
+        if ($existing !== '') {
+            $existing .= "\n";
+        }
+
+        $entry = sprintf(
+            "%s%d:%s\n%s %s %d %s --once\n",
+            self::ONCE_MARKER_PREFIX,
+            $jobId,
+            $target,
+            $schedule,
+            $wrapperScript,
+            $jobId,
+            $target,
+        );
+
+        $this->writeCrontab($user, $existing . $entry);
+
+        $this->logger->info('CrontabManager: once-entry added', [
+            'user'     => $user,
+            'job_id'   => $jobId,
+            'schedule' => $schedule,
+            'target'   => $target,
+        ]);
+    }
+
+    /**
+     * Remove the once-only crontab entry for the given job ID and target.
+     *
+     * Called by the cleanup endpoint after the wrapper finishes a once-only run.
+     * Silently succeeds if no matching entry is found (idempotent).
+     *
+     * @param string $user   Linux user name.
+     * @param int    $jobId  Cronmanager job ID.
+     * @param string $target Execution target to match (e.g. 'local').
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When $user contains disallowed characters.
+     * @throws RuntimeException         When writing the updated crontab fails.
+     */
+    public function removeOnceEntries(string $user, int $jobId, string $target): void
+    {
+        $this->validateUser($user);
+
+        $markerLine = self::ONCE_MARKER_PREFIX . $jobId . ':' . $target;
+        $raw        = $this->readCrontab($user);
+
+        if (!str_contains($raw, $markerLine)) {
+            $this->logger->debug('CrontabManager: removeOnceEntries – no entry found (no-op)', [
+                'user'   => $user,
+                'job_id' => $jobId,
+                'target' => $target,
+            ]);
+            return;
+        }
+
+        $lines    = explode("\n", $raw);
+        $filtered = [];
+        $skipNext = false;
+
+        foreach ($lines as $line) {
+            if ($skipNext) {
+                $skipNext = false;
+                continue;
+            }
+
+            if (trim($line) === $markerLine) {
+                $skipNext = true;
+                continue;
+            }
+
+            $filtered[] = $line;
+        }
+
+        $this->writeCrontab($user, implode("\n", $filtered));
+
+        $this->logger->info('CrontabManager: once-entry removed', [
+            'user'   => $user,
+            'job_id' => $jobId,
+            'target' => $target,
+        ]);
     }
 
     // -------------------------------------------------------------------------

--- a/agent/src/Endpoints/ExecuteCleanupEndpoint.php
+++ b/agent/src/Endpoints/ExecuteCleanupEndpoint.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Cronmanager Host Agent – ExecuteCleanupEndpoint
+ *
+ * Handles POST /crons/{id}/execute/cleanup requests to remove the temporary
+ * once-only crontab entry after it has been executed.
+ *
+ * This endpoint is called by cron-wrapper.sh at the end of a run triggered
+ * via the "Run Now" feature (identified by the "--once" flag).  It is a
+ * best-effort cleanup: even if it fails, the entry carries a full-date
+ * schedule so it fires at most once per year.
+ *
+ * Request body (JSON):
+ * ```json
+ * {"target": "local"}
+ * ```
+ *
+ * Response on success (HTTP 200):
+ * ```json
+ * {"message": "Once-entry removed from crontab.", "job_id": 42, "target": "local"}
+ * ```
+ *
+ * @author  Christian Schulz <technik@meinetechnikwelt.rocks>
+ * @license GNU General Public License version 3 or later
+ */
+
+namespace Cronmanager\Agent\Endpoints;
+
+use Cronmanager\Agent\Cron\CrontabManager;
+use Monolog\Logger;
+use PDO;
+use PDOException;
+
+/**
+ * Class ExecuteCleanupEndpoint
+ *
+ * Removes a once-only crontab entry after its single execution completes.
+ * Called automatically by the cron-wrapper when run with the "--once" flag.
+ */
+final class ExecuteCleanupEndpoint
+{
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    /**
+     * ExecuteCleanupEndpoint constructor.
+     *
+     * @param PDO            $pdo            Active PDO database connection.
+     * @param Logger         $logger         Monolog logger instance.
+     * @param CrontabManager $crontabManager CrontabManager for crontab cleanup.
+     */
+    public function __construct(
+        private readonly PDO            $pdo,
+        private readonly Logger         $logger,
+        private readonly CrontabManager $crontabManager,
+    ) {}
+
+    // -------------------------------------------------------------------------
+    // Handler
+    // -------------------------------------------------------------------------
+
+    /**
+     * Handle a POST /crons/{id}/execute/cleanup request.
+     *
+     * @param array<string, string> $params Path parameters. Expected key: 'id'.
+     *
+     * @return void
+     */
+    public function handle(array $params): void
+    {
+        $jobId = isset($params['id']) ? (int) $params['id'] : 0;
+
+        $this->logger->debug('ExecuteCleanupEndpoint: handling POST /crons/{id}/execute/cleanup', [
+            'job_id' => $jobId,
+        ]);
+
+        if ($jobId <= 0) {
+            jsonResponse(400, [
+                'error'   => 'Bad Request',
+                'message' => 'Invalid or missing job ID.',
+                'code'    => 400,
+            ]);
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // Parse request body
+        // ------------------------------------------------------------------
+
+        $rawBody = (string) file_get_contents('php://input');
+        $body    = json_decode($rawBody, true);
+        $target  = isset($body['target']) ? trim((string) $body['target']) : '';
+
+        if ($target === '') {
+            jsonResponse(400, [
+                'error'   => 'Bad Request',
+                'message' => 'Missing required field: target.',
+                'code'    => 400,
+            ]);
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // Fetch linux_user from DB
+        // ------------------------------------------------------------------
+
+        try {
+            $stmt = $this->pdo->prepare(
+                'SELECT linux_user FROM cronjobs WHERE id = :id'
+            );
+            $stmt->execute([':id' => $jobId]);
+            $row = $stmt->fetch();
+        } catch (PDOException $e) {
+            $this->logger->error('ExecuteCleanupEndpoint: database error', [
+                'job_id'  => $jobId,
+                'message' => $e->getMessage(),
+            ]);
+            jsonResponse(500, [
+                'error'   => 'Internal Server Error',
+                'message' => 'Database error during cleanup.',
+                'code'    => 500,
+            ]);
+            return;
+        }
+
+        if ($row === false) {
+            // Job was deleted between scheduling and cleanup – log and return 200
+            // so the wrapper does not retry. The entry was already removed with
+            // the job, or will expire harmlessly.
+            $this->logger->warning('ExecuteCleanupEndpoint: job not found (may have been deleted)', [
+                'job_id' => $jobId,
+                'target' => $target,
+            ]);
+            jsonResponse(200, [
+                'message' => 'Job not found – no cleanup needed.',
+                'job_id'  => $jobId,
+                'target'  => $target,
+            ]);
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // Remove once-only crontab entry
+        // ------------------------------------------------------------------
+
+        try {
+            $this->crontabManager->removeOnceEntries(
+                (string) $row['linux_user'],
+                $jobId,
+                $target,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('ExecuteCleanupEndpoint: failed to remove once-entry', [
+                'job_id'     => $jobId,
+                'linux_user' => $row['linux_user'],
+                'target'     => $target,
+                'message'    => $e->getMessage(),
+            ]);
+            jsonResponse(500, [
+                'error'   => 'Internal Server Error',
+                'message' => 'Failed to remove once-entry from crontab. It will expire harmlessly next year.',
+                'code'    => 500,
+            ]);
+            return;
+        }
+
+        $this->logger->info('ExecuteCleanupEndpoint: once-entry removed', [
+            'job_id'     => $jobId,
+            'linux_user' => $row['linux_user'],
+            'target'     => $target,
+        ]);
+
+        jsonResponse(200, [
+            'message' => 'Once-entry removed from crontab.',
+            'job_id'  => $jobId,
+            'target'  => $target,
+        ]);
+    }
+}

--- a/agent/src/Endpoints/ExecuteNowEndpoint.php
+++ b/agent/src/Endpoints/ExecuteNowEndpoint.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Cronmanager Host Agent – ExecuteNowEndpoint
+ *
+ * Handles POST /crons/{id}/execute requests to schedule a one-time immediate
+ * execution of a cron job.
+ *
+ * Process:
+ *   1. Validate the job ID and fetch the job (linux_user + targets).
+ *   2. Compute a full-date cron schedule for the next minute:
+ *      "{min} {hour} {dom} {month} *"
+ *      The day-of-month and month fields ensure that even if the cleanup step
+ *      fails, the entry fires at most once per year instead of every hour.
+ *   3. Add a once-only crontab entry per target via CrontabManager::addOnceEntry().
+ *      The wrapper script is invoked with the extra "--once" flag, which triggers
+ *      cleanup after the job finishes.
+ *   4. Return HTTP 200 with the scheduled time and cron expression.
+ *
+ * @author  Christian Schulz <technik@meinetechnikwelt.rocks>
+ * @license GNU General Public License version 3 or later
+ */
+
+namespace Cronmanager\Agent\Endpoints;
+
+use Cronmanager\Agent\Cron\CrontabManager;
+use Monolog\Logger;
+use PDO;
+use PDOException;
+
+/**
+ * Class ExecuteNowEndpoint
+ *
+ * Schedules a one-time immediate (next-minute) execution of a cron job by
+ * inserting a temporary crontab entry with a full-date schedule.
+ *
+ * Response on success (HTTP 200):
+ * ```json
+ * {
+ *   "message": "Job scheduled for immediate execution.",
+ *   "job_id": 42,
+ *   "scheduled_at": "14:37 on 26.03.2026",
+ *   "schedule": "37 14 26 3 *",
+ *   "targets": ["local"]
+ * }
+ * ```
+ */
+final class ExecuteNowEndpoint
+{
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    /**
+     * ExecuteNowEndpoint constructor.
+     *
+     * @param PDO            $pdo            Active PDO database connection.
+     * @param Logger         $logger         Monolog logger instance.
+     * @param CrontabManager $crontabManager CrontabManager for crontab operations.
+     * @param string         $wrapperScript  Absolute path to cron-wrapper.sh.
+     */
+    public function __construct(
+        private readonly PDO            $pdo,
+        private readonly Logger         $logger,
+        private readonly CrontabManager $crontabManager,
+        private readonly string         $wrapperScript,
+    ) {}
+
+    // -------------------------------------------------------------------------
+    // Handler
+    // -------------------------------------------------------------------------
+
+    /**
+     * Handle a POST /crons/{id}/execute request.
+     *
+     * @param array<string, string> $params Path parameters. Expected key: 'id'.
+     *
+     * @return void
+     */
+    public function handle(array $params): void
+    {
+        $jobId = isset($params['id']) ? (int) $params['id'] : 0;
+
+        $this->logger->debug('ExecuteNowEndpoint: handling POST /crons/{id}/execute', [
+            'job_id' => $jobId,
+        ]);
+
+        if ($jobId <= 0) {
+            jsonResponse(400, [
+                'error'   => 'Bad Request',
+                'message' => 'Invalid or missing job ID.',
+                'code'    => 400,
+            ]);
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // 1. Fetch job
+        // ------------------------------------------------------------------
+
+        $job = $this->fetchJob($jobId);
+
+        if ($job === null) {
+            $this->logger->info('ExecuteNowEndpoint: job not found', ['job_id' => $jobId]);
+            jsonResponse(404, [
+                'error'   => 'Not Found',
+                'message' => sprintf('Cron job with ID %d does not exist.', $jobId),
+                'code'    => 404,
+            ]);
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // 2. Resolve targets (fall back to 'local' for legacy jobs)
+        // ------------------------------------------------------------------
+
+        $targets = $this->fetchTargets($jobId);
+        if ($targets === []) {
+            $targets = ['local'];
+        }
+
+        // ------------------------------------------------------------------
+        // 3. Compute full-date schedule for next minute
+        //    Format: "{min} {hour} {dom} {month} *"
+        //    Using day-of-month + month means the entry fires at most once per
+        //    year if the cleanup step fails – far safer than "* * * * *".
+        // ------------------------------------------------------------------
+
+        $next     = new \DateTime('+1 minute');
+        $schedule = sprintf(
+            '%d %d %d %d *',
+            (int) $next->format('i'),  // minute
+            (int) $next->format('G'),  // hour (no leading zero)
+            (int) $next->format('j'),  // day of month (no leading zero)
+            (int) $next->format('n'),  // month (no leading zero)
+        );
+        $scheduledAt = $next->format('H:i') . ' on ' . $next->format('d.m.Y');
+
+        // ------------------------------------------------------------------
+        // 4. Add once-only crontab entries
+        // ------------------------------------------------------------------
+
+        try {
+            foreach ($targets as $target) {
+                $this->crontabManager->addOnceEntry(
+                    (string) $job['linux_user'],
+                    $jobId,
+                    $schedule,
+                    $this->wrapperScript,
+                    $target,
+                );
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('ExecuteNowEndpoint: failed to add once-entry to crontab', [
+                'job_id'  => $jobId,
+                'message' => $e->getMessage(),
+            ]);
+            jsonResponse(500, [
+                'error'   => 'Internal Server Error',
+                'message' => 'Failed to schedule immediate execution. Check agent logs.',
+                'code'    => 500,
+            ]);
+            return;
+        }
+
+        $this->logger->info('ExecuteNowEndpoint: once-execution scheduled', [
+            'job_id'       => $jobId,
+            'linux_user'   => $job['linux_user'],
+            'schedule'     => $schedule,
+            'targets'      => $targets,
+            'scheduled_at' => $scheduledAt,
+        ]);
+
+        jsonResponse(200, [
+            'message'      => 'Job scheduled for immediate execution.',
+            'job_id'       => $jobId,
+            'scheduled_at' => $scheduledAt,
+            'schedule'     => $schedule,
+            'targets'      => $targets,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fetch minimal job data needed for scheduling.
+     *
+     * @param int $jobId Job ID.
+     *
+     * @return array<string, mixed>|null Row with 'id' and 'linux_user', or null.
+     *
+     * @throws PDOException On database errors.
+     */
+    private function fetchJob(int $jobId): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT id, linux_user FROM cronjobs WHERE id = :id'
+        );
+        $stmt->execute([':id' => $jobId]);
+        $row = $stmt->fetch();
+
+        return ($row !== false) ? $row : null;
+    }
+
+    /**
+     * Fetch the execution targets for the given job from job_targets.
+     *
+     * @param int $jobId Job ID.
+     *
+     * @return string[] List of target strings (e.g. ['local', 'ssh-backup-1']).
+     */
+    private function fetchTargets(int $jobId): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT target FROM job_targets WHERE job_id = :id ORDER BY target'
+        );
+        $stmt->execute([':id' => $jobId]);
+
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+}

--- a/web/index.php
+++ b/web/index.php
@@ -187,7 +187,8 @@ try {
     $router->addProtectedRoute('GET',  '/crons/{id}',          [$cronCtrl, 'show']);
     $router->addProtectedRoute('GET',  '/crons/{id}/edit',     [$cronCtrl, 'edit'],    'admin');
     $router->addProtectedRoute('POST', '/crons/{id}/edit',     [$cronCtrl, 'update'],  'admin');
-    $router->addProtectedRoute('POST', '/crons/{id}/delete',   [$cronCtrl, 'destroy'], 'admin');
+    $router->addProtectedRoute('POST', '/crons/{id}/delete',   [$cronCtrl, 'destroy'],    'admin');
+    $router->addProtectedRoute('POST', '/crons/{id}/execute',  [$cronCtrl, 'executeNow'], 'admin');
 
     $router->addProtectedRoute('GET',  '/timeline',            [$timelineCtrl,  'index']);
     $router->addProtectedRoute('GET',  '/swimlane',            [$swimlaneCtrl,  'index']);

--- a/web/lang/de.php
+++ b/web/lang/de.php
@@ -92,6 +92,8 @@ return [
     'cron_copy_title'         => 'Kopie von: {name}',
     'cron_copy_notice'        => 'Felder aus einem bestehenden Job vorausgefüllt. Anpassen und speichern, um einen neuen eigenständigen Job zu erstellen.',
     'cron_delete_confirm'     => 'Möchten Sie diesen Job wirklich löschen?',
+    'cron_run_now'            => 'Ausführen',
+    'cron_run_confirm'        => 'Möchten Sie diesen Job jetzt ausführen? Er wird für die nächste Minute eingeplant.',
     'cron_schedule'           => 'Zeitplan',
     'cron_command'            => 'Befehl',
     'cron_description'        => 'Beschreibung',

--- a/web/lang/en.php
+++ b/web/lang/en.php
@@ -92,6 +92,8 @@ return [
     'cron_copy_title'         => 'Copy of: {name}',
     'cron_copy_notice'        => 'Pre-filled from an existing job. Adjust as needed and save to create a new independent job.',
     'cron_delete_confirm'     => 'Are you sure you want to delete this job?',
+    'cron_run_now'            => 'Run',
+    'cron_run_confirm'        => 'Are you sure you want to execute this job now? It will be scheduled for the next minute.',
     'cron_schedule'           => 'Schedule',
     'cron_command'            => 'Command',
     'cron_description'        => 'Description',

--- a/web/src/Controller/CronController.php
+++ b/web/src/Controller/CronController.php
@@ -762,6 +762,42 @@ class CronController extends BaseController
         (new Response())->redirect($safe);
     }
 
+    /**
+     * Schedule a job for immediate (next-minute) execution via the Run Now button.
+     *
+     * Calls POST /crons/{id}/execute on the agent, which adds a temporary
+     * once-only crontab entry with a full-date schedule.  After execution the
+     * wrapper script calls the cleanup endpoint to remove the entry.
+     *
+     * @param array<string,string> $params Path parameters. Expected key: 'id'.
+     *
+     * @return void
+     */
+    public function executeNow(array $params): void
+    {
+        $id = isset($params['id']) ? (int) $params['id'] : 0;
+
+        $this->logger->info('CronController::executeNow: scheduling immediate execution', ['id' => $id]);
+
+        try {
+            $this->agentClient()->post("/crons/{$id}/execute", []);
+        } catch (\RuntimeException $e) {
+            $this->logger->error('CronController::executeNow: agent error', [
+                'id'    => $id,
+                'error' => $e->getMessage(),
+            ]);
+            $this->renderError(503, 'error_agent_unavailable', '/crons');
+            return;
+        }
+
+        // Redirect back to the referring page (list or detail), validated to
+        // prevent open-redirect.
+        $returnUrl = trim((string) ($_POST['_return'] ?? ''));
+        $safe      = ($returnUrl !== '' && str_starts_with($returnUrl, '/crons')) ? $returnUrl : '/crons';
+
+        (new Response())->redirect($safe);
+    }
+
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------

--- a/web/templates/cron/list.php
+++ b/web/templates/cron/list.php
@@ -416,6 +416,17 @@ $pageUrl = static function (int $targetPage) use ($filterTag, $filterUser, $filt
                                                 <?= htmlspecialchars($t('cron_delete'), ENT_QUOTES, 'UTF-8') ?>
                                             </button>
                                         </form>
+                                        <form method="POST"
+                                              action="/crons/<?= htmlspecialchars(rawurlencode($jobId), ENT_QUOTES, 'UTF-8') ?>/execute"
+                                              onsubmit="return confirm('<?= htmlspecialchars($t('cron_run_confirm'), ENT_QUOTES, 'UTF-8') ?>')">
+                                            <input type="hidden" name="_csrf"   value="<?= htmlspecialchars($csrf_token ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                                            <input type="hidden" name="_return" value="<?= htmlspecialchars($pageUrl($currentPage), ENT_QUOTES, 'UTF-8') ?>">
+                                            <button type="submit"
+                                                    class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold transition"
+                                                    style="background:rgba(251,191,36,.1);color:var(--cm-warning);border:1px solid rgba(251,191,36,.2)">
+                                                <?= htmlspecialchars($t('cron_run_now'), ENT_QUOTES, 'UTF-8') ?>
+                                            </button>
+                                        </form>
                                     </div>
                                 </td>
                             <?php endif; ?>


### PR DESCRIPTION
Adds a yellow "Run" button to each job row in the cron list. On confirmation, the job is scheduled for the next minute via a full-date once-only crontab entry (min hour dom month *) per target. After execution, cron-wrapper.sh calls the new cleanup endpoint to remove the marker+command lines. A missed cleanup expires naturally in at most one year.