### PR TITLE
feat: add self-contained Docker Hub images (v2.1.0)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,89 @@
+################################################################################
+# GitHub Actions – Build and push Docker Hub images on release
+#
+# Trigger: every published GitHub release
+#          (also available as manual dispatch for testing)
+#
+# Images produced:
+#   cs1711/cronmanager-agent:<version>   cs1711/cronmanager-agent:latest
+#   cs1711/cronmanager-web:<version>     cs1711/cronmanager-web:latest
+#
+# Required repository secrets:
+#   DOCKERHUB_USERNAME   – Docker Hub account name (cs1711)
+#   DOCKERHUB_TOKEN      – Docker Hub access token (read/write)
+#
+# @author  Christian Schulz <technik@meinetechnikwelt.rocks>
+# @license GNU General Public License version 3 or later
+################################################################################
+
+name: Build and push Docker images
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag override (e.g. 2.1.0-test). Leave empty to use the release tag."
+        required: false
+        default: ""
+
+jobs:
+  build-and-push:
+    name: Build ${{ matrix.image }} image
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image:      cronmanager-agent
+            dockerfile: docker/agent/Dockerfile
+            context:    .
+          - image:      cronmanager-web
+            dockerfile: docker/web/Dockerfile
+            context:    .
+
+    steps:
+      # ── Checkout ────────────────────────────────────────────────────────────
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # ── Docker Buildx ───────────────────────────────────────────────────────
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ── Docker Hub login ────────────────────────────────────────────────────
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # ── Generate image tags from the release version ─────────────────────
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: cs1711/${{ matrix.image }}
+          tags: |
+            # use manual override if provided (workflow_dispatch only)
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
+            # semver tags from release: v2.1.0 → 2.1.0, 2.1, 2, latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # ── Build and push ───────────────────────────────────────────────────
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v5
+        with:
+          context:    ${{ matrix.context }}
+          file:       ${{ matrix.dockerfile }}
+          push:       true
+          tags:       ${{ steps.meta.outputs.tags }}
+          labels:     ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
+          platforms:  linux/amd64,linux/arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.1.0] – branch: `dockerfull`
+
+### Added
+
+- **Self-contained Docker Hub images** – Two ready-to-use images published on Docker Hub:
+  - `cs1711/cronmanager-agent` – contains the PHP agent source, all Composer dependencies, the database schema, and the container entrypoint.  No host PHP installation or Composer run required.
+  - `cs1711/cronmanager-web` – contains the web application source and all Composer dependencies baked in.  Includes `su-exec` for privilege dropping.
+- **Environment-variable configuration** – Both containers generate their `config.json` at each startup from environment variables.  The minimum required variables are `AGENT_HMAC_SECRET` and `DB_PASSWORD`; all other settings have sensible defaults.
+- **Automatic database schema initialisation** – The agent container waits for MariaDB to become ready (up to 30 retries, 2 s apart) and applies `schema.sql` automatically on the first start if the `cronjobs` table does not yet exist.
+- **`docker/agent/Dockerfile`** – Multi-stage Dockerfile: stage 1 installs Composer dependencies; stage 2 builds the final runtime image from `cs1711/cs_cronmanageragent:latest`.  Vendor tree is baked in at `/opt/phplib/vendor`.
+- **`docker/web/Dockerfile`** – Multi-stage Dockerfile: stage 1 installs Composer dependencies; stage 2 builds the final runtime image from `cs1711/cs_php-nginx-fpm:latest-alpine`.  Vendor tree is baked in at `/var/www/libs/vendor`.
+- **`docker/web/entrypoint.sh`** – Web container entrypoint: generates `config.json`, fixes volume ownership, then drops to `nobody` via `su-exec` before starting supervisord (nginx + PHP-FPM).
+- **`docker/docker-compose-full.yml`** – Minimal Docker Compose file for the Docker Hub deployment.  Uses Docker-managed named volumes (`db-data`, `agent-log`, `web-log`) by default — no host path mounts required.  Host path mount alternatives are provided as commented-out lines.  Only mandatory host mount is `/etc/localtime`.
+- **`.github/workflows/docker-release.yml`** – GitHub Actions workflow that builds and pushes both Docker images on every published GitHub release.  Uses `docker/metadata-action` to generate `v2.1.0`, `2.1`, `2`, and `latest` tags.  Supports `linux/amd64` and `linux/arm64` (multi-platform).
+
+### Changed
+
+- **`docker/agent/entrypoint.sh`** – Extended to generate `config.json` from environment variables before starting, and to wait for MariaDB and apply the schema on first run.
+
+---
+
 ## [2.0.0] – branch: `agentless`
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ history, email failure alerts, multi-host support, and SSO integration.
 
 1. [Features](#features)
 2. [Architecture Overview](#architecture-overview)
-3. [Prerequisites](#prerequisites)
-4. [Guided Setup (Recommended)](#guided-setup-recommended)
-5. [Quick Start](#quick-start)
-6. [Detailed Installation](#detailed-installation)
+3. [Docker Hub – Recommended Installation](#docker-hub--recommended-installation)
+   - [Environment variables reference](#environment-variables-reference)
+4. [Prerequisites](#prerequisites)
+5. [Guided Setup (Alternative)](#guided-setup-alternative)
+6. [Quick Start](#quick-start)
+7. [Detailed Installation](#detailed-installation)
    - [Step 1 – Install PHP and shared libraries on the host](#step-1--install-php-and-shared-libraries-on-the-host)
    - [Step 2 – Deploy the files](#step-2--deploy-the-files)
    - [Step 3 – Configure the host agent](#step-3--configure-the-host-agent)
@@ -27,18 +29,18 @@ history, email failure alerts, multi-host support, and SSO integration.
    - [Step 5 – Configure the web application](#step-5--configure-the-web-application)
    - [Step 6 – Start the Docker stack](#step-6--start-the-docker-stack)
    - [Step 7 – First login and initial setup](#step-7--first-login-and-initial-setup)
-7. [OIDC / SSO Setup with Authentik](#oidc--sso-setup-with-authentik)
-8. [Configuration Reference](#configuration-reference)
+8. [OIDC / SSO Setup with Authentik](#oidc--sso-setup-with-authentik)
+9. [Configuration Reference](#configuration-reference)
    - [Web application config](#web-application-config)
    - [Agent config](#agent-config)
-9. [Email Failure Alerts](#email-failure-alerts)
-10. [Multi-Host Execution](#multi-host-execution)
-11. [Crontab Import](#crontab-import)
-12. [Maintenance](#maintenance)
-13. [Export](#export)
-14. [User Management](#user-management)
-15. [Updating](#updating)
-16. [Troubleshooting](#troubleshooting)
+10. [Email Failure Alerts](#email-failure-alerts)
+11. [Multi-Host Execution](#multi-host-execution)
+12. [Crontab Import](#crontab-import)
+13. [Maintenance](#maintenance)
+14. [Export](#export)
+15. [User Management](#user-management)
+16. [Updating](#updating)
+17. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -127,6 +129,136 @@ A MariaDB container (`cronmanager-db`) stores users, job metadata, tags, and exe
 
 ---
 
+## Docker Hub – Recommended Installation
+
+The simplest way to run Cronmanager is to pull the pre-built images directly from Docker Hub.
+No cloning, no Composer, no PHP on the host — just Docker.
+
+### What you need
+
+| Requirement | Notes |
+|---|---|
+| Docker + Docker Compose v2 | Any recent Linux host |
+| 5 environment variables | See table below |
+
+### Three-step setup
+
+**Step 1 – Create a working directory and a `.env` file**
+
+```bash
+mkdir cronmanager && cd cronmanager
+cat > .env <<'EOF'
+DB_NAME=cronmanager
+DB_USER=cronmanager
+DB_PASSWORD=change-me
+DB_ROOT_PASSWORD=change-me-root
+AGENT_HMAC_SECRET=$(openssl rand -hex 32)
+EOF
+```
+
+> Tip: run `openssl rand -hex 32` separately and paste the output into `AGENT_HMAC_SECRET`.
+
+**Step 2 – Download the Compose file**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/csoscd/cronmanager/main/docker/docker-compose-full.yml \
+    -o docker-compose-full.yml
+```
+
+**Step 3 – Start the stack**
+
+```bash
+docker compose -f docker-compose-full.yml up -d
+```
+
+Open `http://<your-host>:8880/` — the setup wizard appears on first visit and
+lets you create the initial admin account.
+
+### What the stack creates
+
+| Container | Image | Purpose |
+|---|---|---|
+| `cronmanager-db` | `mariadb:latest` | Stores users, jobs, and execution history |
+| `cronmanager-agent` | `cs1711/cronmanager-agent:latest` | Manages crontabs, runs jobs, exposes HMAC API |
+| `cronmanager-web` | `cs1711/cronmanager-web:latest` | PHP-FPM + Nginx web UI |
+
+All persistent data lives in **Docker-managed named volumes** (`db-data`, `agent-log`, `web-log`).
+No host directory mounts are needed.  Optional host-path alternatives are available as
+commented-out lines in `docker-compose-full.yml`.
+
+### Environment variables reference
+
+#### Required (both containers share `AGENT_HMAC_SECRET` and `DB_PASSWORD`)
+
+| Variable | Description |
+|---|---|
+| `AGENT_HMAC_SECRET` | Shared HMAC-SHA256 signing secret (generate with `openssl rand -hex 32`) |
+| `DB_PASSWORD` | MariaDB application user password |
+| `DB_ROOT_PASSWORD` | MariaDB root password (MariaDB container only) |
+| `DB_NAME` | Database name (default: `cronmanager`) |
+| `DB_USER` | Database user (default: `cronmanager`) |
+
+#### Agent container optional variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_BIND_ADDRESS` | `0.0.0.0` | Bind address for the PHP HTTP server |
+| `AGENT_PORT` | `8865` | Listening port |
+| `DB_HOST` | `cronmanager-db` | MariaDB hostname |
+| `LOG_PATH` | `/opt/cronmanager/agent/log/cronmanager-agent.log` | Log file path |
+| `LOG_LEVEL` | `info` | Monolog level (`debug`, `info`, `warning`, `error`) |
+| `LOG_MAX_DAYS` | `30` | Log retention in days |
+| `MAIL_ENABLED` | `false` | Enable email failure alerts |
+| `MAIL_HOST` | `smtp.example.com` | SMTP server hostname |
+| `MAIL_PORT` | `587` | SMTP port |
+| `MAIL_USERNAME` | _(empty)_ | SMTP username |
+| `MAIL_PASSWORD` | _(empty)_ | SMTP password |
+| `MAIL_FROM` | `alerts@example.com` | Sender address |
+| `MAIL_FROM_NAME` | `Cronmanager` | Sender display name |
+| `MAIL_TO` | `admin@example.com` | Alert recipient |
+| `MAIL_ENCRYPTION` | `tls` | `tls` or `ssl` |
+
+#### Web container optional variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_URL` | `http://cronmanager-agent:8865` | Agent base URL |
+| `AGENT_TIMEOUT` | `10` | HTTP timeout in seconds |
+| `DB_HOST` | `cronmanager-db` | MariaDB hostname |
+| `LOG_PATH` | `/var/www/log/cronmanager-web.log` | Log file path |
+| `LOG_LEVEL` | `info` | Monolog level |
+| `LOG_MAX_DAYS` | `30` | Log retention in days |
+| `SESSION_LIFETIME` | `3600` | PHP session lifetime in seconds |
+| `SESSION_NAME` | `cronmanager_sess` | PHP session cookie name |
+| `I18N_LANGUAGE` | `en` | Default UI language (`en` or `de`) |
+| `OIDC_ENABLED` | `false` | Enable OIDC / SSO login |
+| `OIDC_PROVIDER_URL` | _(empty)_ | OIDC provider discovery URL |
+| `OIDC_CLIENT_ID` | _(empty)_ | OAuth 2.0 client ID |
+| `OIDC_CLIENT_SECRET` | _(empty)_ | OAuth 2.0 client secret |
+| `OIDC_REDIRECT_URI` | _(empty)_ | Callback URL registered at the provider |
+| `OIDC_SSL_VERIFY` | `true` | Verify TLS certificate of the OIDC provider |
+| `OIDC_SSL_CA_BUNDLE` | _(empty)_ | Path to custom CA bundle (inside container) |
+
+### Updating to a new release
+
+```bash
+docker compose -f docker-compose-full.yml pull
+docker compose -f docker-compose-full.yml up -d
+```
+
+The agent container automatically applies any new SQL migrations on startup.
+
+### Using SSH for remote job execution
+
+Mount your SSH keys and config into the agent container:
+
+```yaml
+# In docker-compose-full.yml, under cronmanager-agent volumes:
+- /root/.ssh:/root/.ssh:ro
+```
+
+---
+
 ## Prerequisites
 
 | Component | Requirement |
@@ -157,7 +289,7 @@ includes PHP-FPM 8.4 and Nginx.
 
 ---
 
-## Guided Setup (Recommended)
+## Guided Setup (Alternative)
 
 For a fresh installation on a Debian or Ubuntu host, the easiest path is the
 interactive setup script included in the repository.  It guides you through

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -36,7 +36,8 @@ see [README.md](README.md).
 9. [Performance](#performance)
 10. [Configuration Reference](#configuration-reference)
 11. [Deployment Script](#deployment-script)
-12. [Logging](#logging)
+12. [Docker Hub Images](#docker-hub-images)
+13. [Logging](#logging)
 13. [Internationalisation](#internationalisation)
 14. [Adding a New Language](#adding-a-new-language)
 15. [Adding a New Agent Endpoint](#adding-a-new-agent-endpoint)
@@ -81,11 +82,19 @@ In host-agent mode the web container reaches the agent via `host.docker.internal
 ├── deploy.sh                  ← deployment script
 ├── deploy.env[.example]       ← deployment configuration
 ├── db.credentials[.example]   ← database passwords (not in VCS)
+├── .github/
+│   └── workflows/
+│       └── docker-release.yml      ← builds & pushes Docker Hub images on GitHub release
 ├── docker/
 │   ├── docker-compose.yml          ← host-agent mode (web + MariaDB)
-│   ├── docker-compose-agent.yml    ← docker mode (agent + web + MariaDB)
-│   └── agent/
-│       └── entrypoint.sh           ← agent container entrypoint
+│   ├── docker-compose-agent.yml    ← docker mode (agent + web + MariaDB, file-mounted source)
+│   ├── docker-compose-full.yml     ← Docker Hub mode (self-contained images, named volumes)
+│   ├── agent/
+│   │   ├── Dockerfile              ← self-contained agent image
+│   │   └── entrypoint.sh           ← agent container entrypoint (generates config from env)
+│   └── web/
+│       ├── Dockerfile              ← self-contained web image
+│       └── entrypoint.sh          ← web container entrypoint (generates config from env)
 ├── README.md
 ├── TECHNICAL.md
 │
@@ -1301,6 +1310,86 @@ If `DEPLOY_TYPE=SSH`, the SSH host from `deploy.env` can be overridden on the co
 ```bash
 ./deploy.sh --host-agent update staging   # deploy to the "staging" SSH host alias
 ```
+
+---
+
+## Docker Hub Images
+
+The `dockerfull` deployment mode publishes two self-contained images to Docker Hub on
+every GitHub release.  Unlike the `docker` mode (which mounts source code from the host),
+these images have all PHP source and Composer dependencies baked in.
+
+### Image summary
+
+| Image | Base | Entrypoint behaviour |
+|---|---|---|
+| `cs1711/cronmanager-agent` | `cs1711/cs_cronmanageragent:latest` (Debian Trixie, PHP 8.4 CLI, cron, openssh-client) | Generates `config.json`, waits for MariaDB, applies schema, starts cron daemon, then `exec php -S` |
+| `cs1711/cronmanager-web` | `cs1711/cs_php-nginx-fpm:latest-alpine` (Alpine, PHP 8.4 FPM, Nginx, supervisord) | Generates `config.json`, fixes volume ownership, then `su-exec nobody supervisord` |
+
+### Build pipeline
+
+`docker/agent/Dockerfile` and `docker/web/Dockerfile` both use a two-stage build:
+
+1. **`composer:2` stage** – installs all PHP dependencies from `composer.json`.
+2. **Runtime stage** – copies the vendor tree and the application source; no Composer or PHP dev tools remain in the final image.
+
+The images are built and pushed by `.github/workflows/docker-release.yml` on every published
+GitHub release.  The workflow uses `docker/metadata-action` to produce the following tags
+automatically from the release version (e.g. `v2.1.0`):
+
+| Tag | Example |
+|---|---|
+| Full semver | `2.1.0` |
+| Major.minor | `2.1` |
+| Major | `2` |
+| Latest | `latest` |
+
+Multi-platform builds target `linux/amd64` and `linux/arm64`.
+
+### Config-from-environment pattern
+
+Both containers generate their `config.json` at every start — no config volume is required.
+
+**Agent (`docker/agent/entrypoint.sh`):**
+
+```
+1. php -r "echo json_encode([...])"  →  /opt/cronmanager/agent/config/config.json
+2. Wait for MariaDB (30 × 2 s retries)
+3. Apply schema.sql if 'cronjobs' table missing
+4. Fix /root/.ssh permissions if present
+5. Start cron daemon (background)
+6. exec php -S <bind>:<port> agent.php
+```
+
+**Web (`docker/web/entrypoint.sh`):**
+
+```
+1. php84 -r "echo json_encode([...])"  →  /var/www/conf/config.json
+2. chown -R nobody:nobody /var/www/conf /var/www/log
+3. exec su-exec nobody supervisord
+```
+
+### Vendor path inside containers
+
+| Container | Autoloader path |
+|---|---|
+| Agent | `/opt/phplib/vendor/autoload.php` |
+| Web | `/var/www/libs/vendor/autoload.php` |
+
+These paths match the paths used by the non-docker deployment modes, so the PHP source
+files (`Bootstrap.php`, etc.) require no code changes between modes.
+
+### Volumes
+
+All persistent state uses **Docker-managed named volumes** by default.
+Host-path mount alternatives are available as commented-out lines in
+`docker/docker-compose-full.yml`.
+
+| Volume | Container path | Contains |
+|---|---|---|
+| `db-data` | `/var/lib/mysql` (MariaDB) | All database files |
+| `agent-log` | `/opt/cronmanager/agent/log` | Agent log files |
+| `web-log` | `/var/www/log` | Web application log files |
 
 ---
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,57 @@
+# =============================================================================
+# Cronmanager – Docker Hub deployment environment variables
+#
+# Copy this file to .env in the same directory as docker-compose-full.yml
+# and fill in the required values before running:
+#
+#   docker compose -f docker-compose-full.yml up -d
+#
+# Required variables are marked with  ← REQUIRED
+# Optional variables show their defaults.
+# =============================================================================
+
+# ── Database ──────────────────────────────────────────────────────────────────
+DB_NAME=cronmanager
+DB_USER=cronmanager
+DB_PASSWORD=change-me          # ← REQUIRED
+DB_ROOT_PASSWORD=change-me-root # ← REQUIRED
+
+# ── Security ──────────────────────────────────────────────────────────────────
+# Generate with: openssl rand -hex 32
+AGENT_HMAC_SECRET=change-me    # ← REQUIRED
+
+# ── Web UI port ───────────────────────────────────────────────────────────────
+WEB_PORT=8880
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+LOG_LEVEL=info
+LOG_MAX_DAYS=30
+
+# ── Internationalisation ──────────────────────────────────────────────────────
+I18N_LANGUAGE=en
+
+# ── Session ───────────────────────────────────────────────────────────────────
+SESSION_LIFETIME=3600
+
+# ── Agent HTTP timeout (seconds) ─────────────────────────────────────────────
+AGENT_TIMEOUT=10
+
+# ── Email failure alerts (optional) ──────────────────────────────────────────
+# MAIL_ENABLED=true
+# MAIL_HOST=smtp.example.com
+# MAIL_PORT=587
+# MAIL_USERNAME=alerts@example.com
+# MAIL_PASSWORD=secret
+# MAIL_FROM=alerts@example.com
+# MAIL_FROM_NAME=Cronmanager
+# MAIL_TO=admin@example.com
+# MAIL_ENCRYPTION=tls
+
+# ── OIDC / SSO (optional) ─────────────────────────────────────────────────────
+# OIDC_ENABLED=true
+# OIDC_PROVIDER_URL=https://auth.example.com/application/o/cronmanager/
+# OIDC_CLIENT_ID=your-client-id
+# OIDC_CLIENT_SECRET=your-client-secret
+# OIDC_REDIRECT_URI=https://cronmanager.example.com/auth/callback
+# OIDC_SSL_VERIFY=true
+# OIDC_SSL_CA_BUNDLE=

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,0 +1,60 @@
+################################################################################
+# Cronmanager Agent – self-contained Docker image
+#
+# Stages:
+#   1. composer  – installs PHP dependencies with Composer
+#   2. final     – runtime image (cs1711/cs_cronmanageragent:latest)
+#
+# Build from the repository root:
+#   docker build -f docker/agent/Dockerfile -t cs1711/cronmanager-agent:latest .
+#
+# @author  Christian Schulz <technik@meinetechnikwelt.rocks>
+# @license GNU General Public License version 3 or later
+################################################################################
+
+# ── Stage 1: install Composer dependencies ────────────────────────────────────
+FROM composer:2 AS composer-build
+
+WORKDIR /build
+
+# Copy the project-level composer.json (and lock file if present) first so the
+# layer is cached as long as the dependency manifest does not change.
+COPY composer.json ./
+COPY composer.lock* ./
+
+RUN composer install \
+        --no-dev \
+        --no-interaction \
+        --no-progress \
+        --optimize-autoloader \
+        --no-scripts
+
+
+# ── Stage 2: runtime image ────────────────────────────────────────────────────
+FROM cs1711/cs_cronmanageragent:latest
+
+LABEL org.opencontainers.image.title="Cronmanager Agent" \
+      org.opencontainers.image.description="Cronmanager host agent – manages crontabs, records execution results, exposes HMAC-secured HTTP API" \
+      org.opencontainers.image.authors="Christian Schulz <technik@meinetechnikwelt.rocks>" \
+      org.opencontainers.image.licenses="GPL-3.0-or-later" \
+      org.opencontainers.image.source="https://github.com/csoscd/cronmanager"
+
+# Copy Composer-installed vendor tree into the expected path
+COPY --from=composer-build /build/vendor /opt/phplib/vendor
+
+# Copy agent source code
+COPY agent/ /opt/cronmanager/agent/
+
+# Copy the SQL schema so the entrypoint can bootstrap an empty database
+COPY agent/sql/schema.sql /opt/cronmanager/schema.sql
+
+# Copy and configure entrypoint
+COPY docker/agent/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Declare volumes (Docker-managed named volumes by default)
+VOLUME ["/opt/cronmanager/agent/log"]
+
+EXPOSE 8865
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -2,20 +2,38 @@
 # =============================================================================
 # Cronmanager Agent Container – entrypoint.sh
 #
-# Purpose:
-#   Container entrypoint for the docker-only deployment mode.
-#   1. Fixes SSH key permissions (host-mounted keys are often 644).
-#   2. Starts the system cron daemon in the background.
-#   3. Reads agent bind address and port from config.json.
-#   4. Starts the PHP built-in server for the Cronmanager Host Agent.
+# Steps executed on every container start:
+#   1. Generate /opt/cronmanager/agent/config/config.json from environment variables.
+#   2. Wait for MariaDB and apply schema.sql if the 'cronjobs' table is missing.
+#   3. Fix SSH key permissions (host-mounted keys are often 644).
+#   4. Start the system cron daemon in the background.
+#   5. Read bind address and port from the generated config and start the PHP
+#      built-in server as the foreground process (PID 1 equivalent).
 #
-# The PHP CLI server (foreground) is the main process (PID 1-equivalent
-# after exec), so Docker's signal handling works correctly.
-# The cron daemon runs as a background child process.
+# Required environment variables:
+#   AGENT_HMAC_SECRET   – shared secret for HMAC-SHA256 request signing
+#   DB_PASSWORD         – MariaDB password for the application user
 #
-# Environment variables:
-#   AGENT_DIR   – Path inside the container where the agent source is mounted.
-#                 Default: /opt/cronmanager/agent
+# Optional environment variables (shown with their defaults):
+#   AGENT_BIND_ADDRESS  0.0.0.0
+#   AGENT_PORT          8865
+#   DB_HOST             cronmanager-db
+#   DB_PORT             3306
+#   DB_NAME             cronmanager
+#   DB_USER             cronmanager
+#   LOG_PATH            /opt/cronmanager/agent/log/cronmanager-agent.log
+#   LOG_LEVEL           info
+#   LOG_MAX_DAYS        30
+#   MAIL_ENABLED        false
+#   MAIL_HOST           smtp.example.com
+#   MAIL_PORT           587
+#   MAIL_USERNAME       ""
+#   MAIL_PASSWORD       ""
+#   MAIL_FROM           alerts@example.com
+#   MAIL_FROM_NAME      Cronmanager
+#   MAIL_TO             admin@example.com
+#   MAIL_ENCRYPTION     tls
+#   CRON_WRAPPER_SCRIPT /opt/cronmanager/agent/bin/cron-wrapper.sh
 #
 # @author  Christian Schulz <technik@meinetechnikwelt.rocks>
 # @license GNU General Public License version 3 or later
@@ -25,6 +43,7 @@ set -uo pipefail
 
 AGENT_DIR="${AGENT_DIR:-/opt/cronmanager/agent}"
 CONFIG_FILE="${AGENT_DIR}/config/config.json"
+SCHEMA_FILE="${SCHEMA_FILE:-/opt/cronmanager/schema.sql}"
 
 # ── Logging helpers ───────────────────────────────────────────────────────────
 log_info()  { echo "[entrypoint] [INFO]  $(date -Iseconds) $*"; }
@@ -32,22 +51,160 @@ log_warn()  { echo "[entrypoint] [WARN]  $(date -Iseconds) $*"; }
 log_error() { echo "[entrypoint] [ERROR] $(date -Iseconds) $*" >&2; }
 
 # =============================================================================
-# 1. Fix SSH key permissions
+# 1. Generate config.json from environment variables
+# =============================================================================
+
+log_info "Generating ${CONFIG_FILE} from environment variables..."
+
+# Validate required variables
+if [[ -z "${AGENT_HMAC_SECRET:-}" ]]; then
+    log_error "AGENT_HMAC_SECRET is required but not set."
+    exit 1
+fi
+if [[ -z "${DB_PASSWORD:-}" ]]; then
+    log_error "DB_PASSWORD is required but not set."
+    exit 1
+fi
+
+mkdir -p "${AGENT_DIR}/config"
+
+php -r "
+\$config = [
+    'agent' => [
+        'bind_address' => getenv('AGENT_BIND_ADDRESS') ?: '0.0.0.0',
+        'port'         => (int)(getenv('AGENT_PORT') ?: 8865),
+        'hmac_secret'  => getenv('AGENT_HMAC_SECRET'),
+    ],
+    'database' => [
+        'host'     => getenv('DB_HOST') ?: 'cronmanager-db',
+        'port'     => (int)(getenv('DB_PORT') ?: 3306),
+        'name'     => getenv('DB_NAME') ?: 'cronmanager',
+        'user'     => getenv('DB_USER') ?: 'cronmanager',
+        'password' => getenv('DB_PASSWORD'),
+    ],
+    'logging' => [
+        'path'     => getenv('LOG_PATH') ?: '/opt/cronmanager/agent/log/cronmanager-agent.log',
+        'level'    => getenv('LOG_LEVEL') ?: 'info',
+        'max_days' => (int)(getenv('LOG_MAX_DAYS') ?: 30),
+    ],
+    'mail' => [
+        'enabled'   => filter_var(getenv('MAIL_ENABLED') ?: 'false', FILTER_VALIDATE_BOOLEAN),
+        'host'      => getenv('MAIL_HOST') ?: 'smtp.example.com',
+        'port'      => (int)(getenv('MAIL_PORT') ?: 587),
+        'username'  => getenv('MAIL_USERNAME') ?: '',
+        'password'  => getenv('MAIL_PASSWORD') ?: '',
+        'from'      => getenv('MAIL_FROM') ?: 'alerts@example.com',
+        'from_name' => getenv('MAIL_FROM_NAME') ?: 'Cronmanager',
+        'to'        => getenv('MAIL_TO') ?: 'admin@example.com',
+        'encryption'=> getenv('MAIL_ENCRYPTION') ?: 'tls',
+    ],
+    'cron' => [
+        'wrapper_script' => getenv('CRON_WRAPPER_SCRIPT') ?: '/opt/cronmanager/agent/bin/cron-wrapper.sh',
+    ],
+];
+file_put_contents('${CONFIG_FILE}', json_encode(\$config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+echo 'Config written.' . PHP_EOL;
+"
+
+log_info "Config written to ${CONFIG_FILE}."
+
+# =============================================================================
+# 2. Wait for MariaDB and apply schema if needed
+# =============================================================================
+
+DB_HOST="${DB_HOST:-cronmanager-db}"
+DB_PORT="${DB_PORT:-3306}"
+DB_NAME="${DB_NAME:-cronmanager}"
+DB_USER="${DB_USER:-cronmanager}"
+
+log_info "Waiting for MariaDB at ${DB_HOST}:${DB_PORT}..."
+
+MAX_RETRIES=30
+RETRY_WAIT=2
+CONNECTED=false
+
+for i in $(seq 1 $MAX_RETRIES); do
+    if php -r "
+        try {
+            \$pdo = new PDO(
+                'mysql:host=${DB_HOST};port=${DB_PORT};dbname=${DB_NAME}',
+                '${DB_USER}',
+                getenv('DB_PASSWORD'),
+                [PDO::ATTR_TIMEOUT => 3]
+            );
+            exit(0);
+        } catch (Exception \$e) {
+            exit(1);
+        }
+    " 2>/dev/null; then
+        CONNECTED=true
+        log_info "MariaDB is reachable (attempt ${i}/${MAX_RETRIES})."
+        break
+    fi
+    log_info "MariaDB not ready yet (attempt ${i}/${MAX_RETRIES}), retrying in ${RETRY_WAIT}s..."
+    sleep $RETRY_WAIT
+done
+
+if [[ "$CONNECTED" == false ]]; then
+    log_error "Could not connect to MariaDB after ${MAX_RETRIES} attempts. Aborting."
+    exit 1
+fi
+
+# Apply schema.sql if the 'cronjobs' table does not yet exist
+log_info "Checking database schema..."
+TABLE_EXISTS=$(php -r "
+    try {
+        \$pdo = new PDO(
+            'mysql:host=${DB_HOST};port=${DB_PORT};dbname=${DB_NAME}',
+            '${DB_USER}',
+            getenv('DB_PASSWORD')
+        );
+        \$stmt = \$pdo->query(\"SHOW TABLES LIKE 'cronjobs'\");
+        echo \$stmt->rowCount() > 0 ? 'yes' : 'no';
+    } catch (Exception \$e) {
+        echo 'error: ' . \$e->getMessage();
+        exit(1);
+    }
+" 2>/dev/null)
+
+if [[ "$TABLE_EXISTS" == "no" ]]; then
+    log_info "Schema not found – applying ${SCHEMA_FILE}..."
+    if [[ ! -f "$SCHEMA_FILE" ]]; then
+        log_error "Schema file not found: ${SCHEMA_FILE}"
+        exit 1
+    fi
+    php -r "
+        \$sql = file_get_contents('${SCHEMA_FILE}');
+        try {
+            \$pdo = new PDO(
+                'mysql:host=${DB_HOST};port=${DB_PORT};dbname=${DB_NAME}',
+                '${DB_USER}',
+                getenv('DB_PASSWORD')
+            );
+            \$pdo->exec(\$sql);
+            echo 'Schema applied successfully.' . PHP_EOL;
+        } catch (Exception \$e) {
+            fwrite(STDERR, 'Schema init failed: ' . \$e->getMessage() . PHP_EOL);
+            exit(1);
+        }
+    "
+    log_info "Database schema initialised."
+elif [[ "$TABLE_EXISTS" == "yes" ]]; then
+    log_info "Database schema already present – skipping init."
+else
+    log_warn "Could not determine schema state (${TABLE_EXISTS}) – continuing anyway."
+fi
+
+# =============================================================================
+# 3. Fix SSH key permissions
 #    The host's ~/.ssh directory is mounted read-only.  SSH refuses to use
 #    keys if the directory or files have permissions wider than 0700/0600.
 #    We copy the keys to a writable location and fix permissions there.
 # =============================================================================
 
 if [[ -d /root/.ssh ]]; then
-    # The mount is read-only, but we can at least check connectivity.
-    # SSH only cares about the permissions of the *actual* files, so we
-    # ensure the owning user's umask is correct within the container.
-    # If the host fs exports the files with correct permissions no action
-    # is needed; if not, copy to a writable location.
-
     SSH_PERMS_OK=true
 
-    # Check directory permission
     _dir_perm=$(stat -c '%a' /root/.ssh 2>/dev/null || echo "000")
     if [[ "$_dir_perm" != "700" && "$_dir_perm" != "600" ]]; then
         SSH_PERMS_OK=false
@@ -59,7 +216,6 @@ if [[ -d /root/.ssh ]]; then
         cp -rp /root/.ssh/. /root/.ssh-rw/ 2>/dev/null || true
         chmod 700 /root/.ssh-rw
         find /root/.ssh-rw -type f -exec chmod 600 {} \;
-        # Redirect SSH config to the writable copy
         export HOME_SSH=/root/.ssh-rw
         log_info "SSH keys copied to /root/.ssh-rw with correct permissions."
     else
@@ -70,7 +226,7 @@ else
 fi
 
 # =============================================================================
-# 2. Start cron daemon
+# 4. Start cron daemon
 # =============================================================================
 
 log_info "Starting cron daemon..."
@@ -79,9 +235,10 @@ CRON_PID=$!
 log_info "Cron daemon started (PID ${CRON_PID})."
 
 # =============================================================================
-# 3. Read bind address and port from config.json
+# 5. Start PHP built-in server (foreground – becomes main process)
 # =============================================================================
 
+# Re-read bind address and port from the generated config file
 BIND_ADDRESS="0.0.0.0"
 PORT="8865"
 
@@ -93,9 +250,6 @@ if [[ -f "$CONFIG_FILE" ]]; then
     " 2>/dev/null || echo "0.0.0.0 8865")
     BIND_ADDRESS="${_parsed%% *}"
     PORT="${_parsed##* }"
-    log_info "Config loaded: bind=${BIND_ADDRESS} port=${PORT}"
-else
-    log_warn "Config file not found at ${CONFIG_FILE} – using defaults (0.0.0.0:8865)."
 fi
 
 AGENT_PHP="${AGENT_DIR}/agent.php"
@@ -103,10 +257,6 @@ if [[ ! -f "$AGENT_PHP" ]]; then
     log_error "Agent entry point not found: ${AGENT_PHP}"
     exit 1
 fi
-
-# =============================================================================
-# 4. Start PHP built-in server (foreground – becomes main process)
-# =============================================================================
 
 log_info "Starting Cronmanager agent on ${BIND_ADDRESS}:${PORT}"
 exec php -S "${BIND_ADDRESS}:${PORT}" "${AGENT_PHP}"

--- a/docker/docker-compose-full.yml
+++ b/docker/docker-compose-full.yml
@@ -1,0 +1,156 @@
+################################################################################
+# Cronmanager – Full Docker Hub Deployment
+#
+# All three components run as Docker containers.  No local checkout or PHP
+# installation on the host is required.
+#
+# Quick start:
+#   1. Copy .env.example to .env and fill in the required values.
+#   2. docker compose -f docker-compose-full.yml up -d
+#   3. Open http://<host>:8880/ – the setup wizard creates the first admin.
+#
+# Required environment variables (set in .env or export them):
+#   DB_NAME              – database name (e.g. cronmanager)
+#   DB_USER              – database application user
+#   DB_PASSWORD          – database application user password
+#   DB_ROOT_PASSWORD     – MariaDB root password
+#   AGENT_HMAC_SECRET    – shared HMAC secret (generate: openssl rand -hex 32)
+#
+# @author  Christian Schulz <technik@meinetechnikwelt.rocks>
+# @license GNU General Public License version 3 or later
+################################################################################
+
+services:
+
+  # ── MariaDB ─────────────────────────────────────────────────────────────────
+  cronmanager-db:
+    image: mariadb:latest
+    container_name: cronmanager-db
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
+      MARIADB_DATABASE:      "${DB_NAME:-cronmanager}"
+      MARIADB_USER:          "${DB_USER:-cronmanager}"
+      MARIADB_PASSWORD:      "${DB_PASSWORD}"
+    networks:
+      - cronmanager-internal
+    volumes:
+      # Docker-managed named volume (default – no host path required)
+      - db-data:/var/lib/mysql
+      # Optional: host path mount instead of named volume
+      # - /opt/cronmanager/db:/var/lib/mysql
+      - /etc/localtime:/etc/localtime:ro
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── Cronmanager Agent ───────────────────────────────────────────────────────
+  cronmanager-agent:
+    image: cs1711/cronmanager-agent:latest
+    container_name: cronmanager-agent
+    restart: unless-stopped
+    depends_on:
+      cronmanager-db:
+        condition: service_healthy
+    environment:
+      # Required
+      AGENT_HMAC_SECRET: "${AGENT_HMAC_SECRET}"
+      DB_PASSWORD:        "${DB_PASSWORD}"
+      # Database (defaults match service names above)
+      DB_HOST:  "cronmanager-db"
+      DB_PORT:  "3306"
+      DB_NAME:  "${DB_NAME:-cronmanager}"
+      DB_USER:  "${DB_USER:-cronmanager}"
+      # Agent HTTP server
+      AGENT_BIND_ADDRESS: "0.0.0.0"
+      AGENT_PORT:         "8865"
+      # Logging
+      LOG_PATH:     "/opt/cronmanager/agent/log/cronmanager-agent.log"
+      LOG_LEVEL:    "${LOG_LEVEL:-info}"
+      LOG_MAX_DAYS: "${LOG_MAX_DAYS:-30}"
+      # Optional: email failure alerts
+      # MAIL_ENABLED:   "true"
+      # MAIL_HOST:      "smtp.example.com"
+      # MAIL_PORT:      "587"
+      # MAIL_USERNAME:  "alerts@example.com"
+      # MAIL_PASSWORD:  "secret"
+      # MAIL_FROM:      "alerts@example.com"
+      # MAIL_FROM_NAME: "Cronmanager"
+      # MAIL_TO:        "admin@example.com"
+      # MAIL_ENCRYPTION: "tls"
+    networks:
+      - cronmanager-internal
+    volumes:
+      # Docker-managed named volume for agent logs (default)
+      - agent-log:/opt/cronmanager/agent/log
+      # Optional: persist logs on the host instead
+      # - /opt/cronmanager/agent/log:/opt/cronmanager/agent/log
+      - /etc/localtime:/etc/localtime:ro
+      # Optional: SSH keys for remote job execution
+      # - /root/.ssh:/root/.ssh:ro
+    expose:
+      - "8865"
+
+  # ── Cronmanager Web UI ──────────────────────────────────────────────────────
+  cronmanager-web:
+    image: cs1711/cronmanager-web:latest
+    container_name: cronmanager-web
+    restart: unless-stopped
+    depends_on:
+      cronmanager-db:
+        condition: service_healthy
+    ports:
+      - "${WEB_PORT:-8880}:8080"
+    environment:
+      # Required
+      AGENT_HMAC_SECRET: "${AGENT_HMAC_SECRET}"
+      DB_PASSWORD:        "${DB_PASSWORD}"
+      # Agent connection (uses Docker service name)
+      AGENT_URL:     "http://cronmanager-agent:8865"
+      AGENT_TIMEOUT: "${AGENT_TIMEOUT:-10}"
+      # Database
+      DB_HOST: "cronmanager-db"
+      DB_PORT: "3306"
+      DB_NAME: "${DB_NAME:-cronmanager}"
+      DB_USER: "${DB_USER:-cronmanager}"
+      # Logging
+      LOG_PATH:     "/var/www/log/cronmanager-web.log"
+      LOG_LEVEL:    "${LOG_LEVEL:-info}"
+      LOG_MAX_DAYS: "${LOG_MAX_DAYS:-30}"
+      # Session
+      SESSION_LIFETIME: "${SESSION_LIFETIME:-3600}"
+      SESSION_NAME:     "cronmanager_sess"
+      # Internationalisation
+      I18N_LANGUAGE: "${I18N_LANGUAGE:-en}"
+      # Optional: OIDC / SSO
+      # OIDC_ENABLED:        "true"
+      # OIDC_PROVIDER_URL:   "https://auth.example.com/application/o/cronmanager/"
+      # OIDC_CLIENT_ID:      "your-client-id"
+      # OIDC_CLIENT_SECRET:  "your-client-secret"
+      # OIDC_REDIRECT_URI:   "https://cronmanager.example.com/auth/callback"
+      # OIDC_SSL_VERIFY:     "true"
+      # OIDC_SSL_CA_BUNDLE:  ""
+    networks:
+      - cronmanager-internal
+    volumes:
+      # Docker-managed named volume for web logs (default)
+      - web-log:/var/www/log
+      # Optional: persist logs on the host instead
+      # - /opt/cronmanager/www/log:/var/www/log
+      - /etc/localtime:/etc/localtime:ro
+
+
+# ── Named volumes (Docker-managed, no host paths required) ──────────────────
+volumes:
+  db-data:
+  agent-log:
+  web-log:
+
+
+# ── Private internal network ────────────────────────────────────────────────
+networks:
+  cronmanager-internal:
+    driver: bridge

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,74 @@
+################################################################################
+# Cronmanager Web – self-contained Docker image
+#
+# Stages:
+#   1. composer  – installs PHP dependencies with Composer
+#   2. final     – runtime image (cs1711/cs_php-nginx-fpm:latest-alpine)
+#
+# Build from the repository root:
+#   docker build -f docker/web/Dockerfile -t cs1711/cronmanager-web:latest .
+#
+# Notes:
+#   * The base image runs as USER nobody; the entrypoint drops back to nobody
+#     after writing the config file (requires su-exec).
+#   * PHP binary on alpine is php84, not php.
+#
+# @author  Christian Schulz <technik@meinetechnikwelt.rocks>
+# @license GNU General Public License version 3 or later
+################################################################################
+
+# ── Stage 1: install Composer dependencies ────────────────────────────────────
+FROM composer:2 AS composer-build
+
+WORKDIR /build
+
+COPY composer.json ./
+COPY composer.lock* ./
+
+RUN composer install \
+        --no-dev \
+        --no-interaction \
+        --no-progress \
+        --optimize-autoloader \
+        --no-scripts
+
+
+# ── Stage 2: runtime image ────────────────────────────────────────────────────
+FROM cs1711/cs_php-nginx-fpm:latest-alpine
+
+LABEL org.opencontainers.image.title="Cronmanager Web" \
+      org.opencontainers.image.description="Cronmanager web UI – PHP-FPM + Nginx, config from environment variables" \
+      org.opencontainers.image.authors="Christian Schulz <technik@meinetechnikwelt.rocks>" \
+      org.opencontainers.image.licenses="GPL-3.0-or-later" \
+      org.opencontainers.image.source="https://github.com/csoscd/cronmanager"
+
+# Switch to root to install su-exec and copy files
+USER root
+
+# su-exec is needed to drop from root to nobody after writing the config file
+RUN apk add --no-cache su-exec
+
+# Copy Composer-installed vendor tree
+COPY --from=composer-build --chown=nobody:nobody /build/vendor /var/www/libs/vendor
+
+# Copy web application source
+COPY --chown=nobody:nobody web/ /var/www/html/
+
+# Pre-create directories that will be used at runtime
+RUN mkdir -p /var/www/conf /var/www/log \
+    && chown -R nobody:nobody /var/www/conf /var/www/log
+
+# Copy and configure entrypoint
+COPY docker/web/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Declare log volume (Docker-managed named volume by default)
+VOLUME ["/var/www/log"]
+
+EXPOSE 8080
+
+# Run as root so the entrypoint can write the config file;
+# the entrypoint then drops to nobody via su-exec before starting supervisord.
+USER root
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Cronmanager Web Container – entrypoint.sh
+#
+# Steps executed on every container start:
+#   1. Generate /var/www/conf/config.json from environment variables.
+#   2. Fix ownership of /var/www/conf and /var/www/log for the nobody user.
+#   3. Drop privileges to nobody and exec supervisord (nginx + php-fpm).
+#
+# Required environment variables:
+#   AGENT_HMAC_SECRET   – shared secret for HMAC-SHA256 request signing
+#   DB_PASSWORD         – MariaDB password for the application user
+#
+# Optional environment variables (shown with their defaults):
+#   AGENT_URL           http://cronmanager-agent:8865
+#   AGENT_TIMEOUT       10
+#   DB_HOST             cronmanager-db
+#   DB_PORT             3306
+#   DB_NAME             cronmanager
+#   DB_USER             cronmanager
+#   LOG_PATH            /var/www/log/cronmanager-web.log
+#   LOG_LEVEL           info
+#   LOG_MAX_DAYS        30
+#   SESSION_LIFETIME    3600
+#   SESSION_NAME        cronmanager_sess
+#   I18N_LANGUAGE       en
+#   OIDC_ENABLED        false
+#   OIDC_PROVIDER_URL   ""
+#   OIDC_CLIENT_ID      ""
+#   OIDC_CLIENT_SECRET  ""
+#   OIDC_REDIRECT_URI   ""
+#   OIDC_SSL_VERIFY     true
+#   OIDC_SSL_CA_BUNDLE  ""
+#
+# @author  Christian Schulz <technik@meinetechnikwelt.rocks>
+# @license GNU General Public License version 3 or later
+# =============================================================================
+
+set -uo pipefail
+
+CONFIG_FILE="/var/www/conf/config.json"
+
+# ── Logging helpers ───────────────────────────────────────────────────────────
+log_info()  { echo "[entrypoint] [INFO]  $(date -Iseconds) $*"; }
+log_warn()  { echo "[entrypoint] [WARN]  $(date -Iseconds) $*"; }
+log_error() { echo "[entrypoint] [ERROR] $(date -Iseconds) $*" >&2; }
+
+# =============================================================================
+# 1. Generate config.json from environment variables
+# =============================================================================
+
+log_info "Generating ${CONFIG_FILE} from environment variables..."
+
+# Validate required variables
+if [[ -z "${AGENT_HMAC_SECRET:-}" ]]; then
+    log_error "AGENT_HMAC_SECRET is required but not set."
+    exit 1
+fi
+if [[ -z "${DB_PASSWORD:-}" ]]; then
+    log_error "DB_PASSWORD is required but not set."
+    exit 1
+fi
+
+mkdir -p /var/www/conf
+
+# The alpine base image uses php84, not php
+php84 -r "
+\$config = [
+    'database' => [
+        'host'     => getenv('DB_HOST') ?: 'cronmanager-db',
+        'port'     => (int)(getenv('DB_PORT') ?: 3306),
+        'name'     => getenv('DB_NAME') ?: 'cronmanager',
+        'user'     => getenv('DB_USER') ?: 'cronmanager',
+        'password' => getenv('DB_PASSWORD'),
+    ],
+    'agent' => [
+        'url'         => getenv('AGENT_URL') ?: 'http://cronmanager-agent:8865',
+        'hmac_secret' => getenv('AGENT_HMAC_SECRET'),
+        'timeout'     => (int)(getenv('AGENT_TIMEOUT') ?: 10),
+    ],
+    'logging' => [
+        'path'     => getenv('LOG_PATH') ?: '/var/www/log/cronmanager-web.log',
+        'level'    => getenv('LOG_LEVEL') ?: 'info',
+        'max_days' => (int)(getenv('LOG_MAX_DAYS') ?: 30),
+    ],
+    'session' => [
+        'lifetime' => (int)(getenv('SESSION_LIFETIME') ?: 3600),
+        'name'     => getenv('SESSION_NAME') ?: 'cronmanager_sess',
+    ],
+    'i18n' => [
+        'default_language' => getenv('I18N_LANGUAGE') ?: 'en',
+        'available'        => ['en', 'de'],
+    ],
+    'auth' => [
+        'oidc_enabled'       => filter_var(getenv('OIDC_ENABLED') ?: 'false', FILTER_VALIDATE_BOOLEAN),
+        'oidc_provider_url'  => getenv('OIDC_PROVIDER_URL') ?: '',
+        'oidc_client_id'     => getenv('OIDC_CLIENT_ID') ?: '',
+        'oidc_client_secret' => getenv('OIDC_CLIENT_SECRET') ?: '',
+        'oidc_redirect_uri'  => getenv('OIDC_REDIRECT_URI') ?: '',
+        'oidc_ssl_verify'    => filter_var(getenv('OIDC_SSL_VERIFY') ?: 'true', FILTER_VALIDATE_BOOLEAN),
+        'oidc_ssl_ca_bundle' => getenv('OIDC_SSL_CA_BUNDLE') ?: '',
+    ],
+];
+file_put_contents('${CONFIG_FILE}', json_encode(\$config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+echo 'Config written.' . PHP_EOL;
+"
+
+log_info "Config written to ${CONFIG_FILE}."
+
+# =============================================================================
+# 2. Fix directory ownership for the nobody user
+# =============================================================================
+
+chown -R nobody:nobody /var/www/conf /var/www/log
+log_info "Ownership of /var/www/conf and /var/www/log set to nobody."
+
+# =============================================================================
+# 3. Drop privileges and start supervisord (nginx + php-fpm)
+# =============================================================================
+
+log_info "Starting supervisord as nobody..."
+exec su-exec nobody /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
- docker/agent/Dockerfile: multi-stage build, Composer deps baked in, source copied from repo, schema.sql included for auto-init
- docker/web/Dockerfile: multi-stage build, su-exec added for privilege drop, web source and vendor tree baked in
- docker/agent/entrypoint.sh: generates config.json from env vars, waits for MariaDB, applies schema on first run, then starts agent
- docker/web/entrypoint.sh: generates config.json from env vars via php84, fixes volume ownership, drops to nobody via su-exec
- docker/docker-compose-full.yml: three-service stack using Docker Hub images and named volumes (no host paths required by default)
- docker/.env.example: minimal env file template for the full stack
- .github/workflows/docker-release.yml: GitHub Actions workflow that builds and pushes both images on every published release; produces semver tags and multi-platform linux/amd64+arm64 images
- CHANGELOG.md: add [2.1.0] section
- README.md: Docker Hub installation as the preferred/first method, full env var reference table
- TECHNICAL.md: add Docker Hub Images section with build pipeline, config-from-env pattern, volume and vendor path documentation; update directory layout and table of contents