### PR TITLE
docs: update CHANGELOG, README, TECHNICAL and SECURITY for v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.2.0] – branch: `dockerfull`
+
+### Fixed
+
+- **Web container: Alpine shell compatibility** – `docker/web/entrypoint.sh` used `#!/bin/bash` and bash-specific syntax (`[[ ]]`). The runtime base image (`cs_php-nginx-fpm:latest-alpine`) is Alpine Linux which has no bash. Changed shebang to `#!/bin/sh`, replaced all `[[ ]]` test constructs with POSIX `[ ]`, and removed bash-specific constructs throughout.
+- **Web container: supervisord permission errors (EACCES)** – The previous entrypoint used `su-exec nobody supervisord`, causing supervisord to start as `nobody`. supervisord requires root to create its dispatcher sockets and manage child processes; it emitted `EACCES` and failed to start nginx and PHP-FPM. Removed `su-exec`; supervisord now starts as root and nginx/PHP-FPM drop privileges internally via their own configuration (see below).
+- **Web container: PHP-FPM pool user not defined** – The base image expected the PHP-FPM master to already be running as `nobody`; without an explicit `user=` line in `www.conf` the pool failed with `[pool www] user has not been defined`. The `docker/web/Dockerfile` now appends `user=nobody`, `group=nobody`, `listen.owner=nobody`, `listen.group=nobody`, and `listen.mode=0660` to `www.conf` at build time.
+- **Web container: nginx socket permission denied** – When supervisord ran as root the PHP-FPM socket was owned by root; nginx workers ran as `nginx` (a different user) and received `Permission denied` on the socket. The `docker/web/Dockerfile` now patches `nginx.conf` to set `user nobody` so that nginx workers match the PHP-FPM socket owner.
+- **Web container: missing Tailwind CSS and Chart.js assets** – The web image had no `assets/js/` directory; Tailwind CSS and Chart.js were neither committed to the repository nor downloaded during the image build, causing broken page layout and missing charts. The `docker/web/Dockerfile` now downloads both assets via `wget` during the build stage so they are always present in the final image.
+- **`docker-compose-full.yml`: `mariadb:latest` replaced with `mariadb:lts`** – Using `:latest` on the MariaDB image risks unexpected major-version upgrades on `docker pull`. Changed to `:lts` to track the Long-Term Support release line.
+
+### Added
+
+- **`.github/workflows/auto-patch-release.yml`** – New workflow that automates patch version bumps when the upstream base images are rebuilt. Triggered by `workflow_dispatch` (manual, GitHub Actions UI) or `repository_dispatch` (programmatic, via `curl` or `gh workflow run` from the build machine). Reads the latest git tag, increments the patch digit (e.g. `v2.1.0` → `v2.1.1`), and creates a GitHub release. The existing `docker-release.yml` fires on the new release and rebuilds and pushes both Docker Hub images with the updated base image baked in.
+- **GitHub Actions: Node.js 24 compatibility** – Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a workflow-level environment variable in `docker-release.yml` to silence Node.js 20 deprecation warnings emitted by the GitHub Actions runner. Bumped `docker/build-push-action` to `@v6`.
+
+### Changed
+
+- **`docker/docker-compose-full.yml`: SSH key mount added by default** – The agent service now includes a `/root/.ssh:/root/.ssh:ro` volume mount. Without this mount the agent container has no SSH keys or known-hosts file, so crontab import and remote job execution against SSH targets silently fail. An agent-specific directory alternative (`/opt/cronmanager/.ssh`) is documented in `README.md` for installations that require key isolation.
+- **`simple_debian_setup.sh` v2.0.0: docker-only mode removed** – The interactive `docker-only` deployment path (Step 1b, all associated conditionals) has been removed. The script now exclusively supports host-agent mode (PHP CLI + systemd service). This simplifies the guided setup considerably and avoids the overlap with the recommended Docker Hub installation path. Users who want a fully containerised agent should follow the Docker Hub setup described in `README.md`.
+
+---
+
 ## [2.1.0] – branch: `dockerfull`
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ lets you create the initial admin account.
 
 | Container | Image | Purpose |
 |---|---|---|
-| `cronmanager-db` | `mariadb:latest` | Stores users, jobs, and execution history |
+| `cronmanager-db` | `mariadb:lts` | Stores users, jobs, and execution history |
 | `cronmanager-agent` | `cs1711/cronmanager-agent:latest` | Manages crontabs, runs jobs, exposes HMAC API |
 | `cronmanager-web` | `cs1711/cronmanager-web:latest` | PHP-FPM + Nginx web UI |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -181,7 +181,11 @@ stores both verifier and `state` in the PHP session. Both are verified before th
 **Status / recommendation**:
 - Browser → Web UI: HTTPS should be configured at the reverse-proxy / Docker ingress level.
   The application itself does not handle TLS termination.
-- Web container → Host agent: Uses HTTP. In host-agent mode the web container reaches the agent via `host.docker.internal` (Docker bridge to host loopback, not externally routable). In docker mode traffic stays on the private `cronmanager-internal` Docker network and never leaves the host. In both cases the HMAC signature ensures integrity and authenticity even without TLS on this hop.
+- Web container → Host agent: Uses HTTP. The exposure depends on the deployment mode:
+  - **Host-agent mode**: The web container reaches the agent via `host.docker.internal` (Docker bridge to the host's loopback interface, not externally routable).
+  - **Docker mode** (file-mounted source): Traffic stays on the private `cronmanager-internal` Docker network and never leaves the host.
+  - **Docker Hub mode** (`docker-compose-full.yml`): All three services (web, agent, MariaDB) share a private named Docker network; web→agent traffic is container-to-container and never leaves the host.
+  - In all cases the HMAC signature ensures integrity and authenticity of requests even without TLS on this internal hop.
 - **Recommendation**: Add TLS to the host agent listener for defence-in-depth if the Docker network
   is shared with untrusted containers.
 
@@ -463,5 +467,5 @@ Use this checklist when deploying a new instance or reviewing after changes.
 
 ---
 
-*Analysis performed: 2026-03-18*
+*Analysis performed: 2026-03-18; last updated: 2026-03-30*
 *Analyst: Christian Schulz <technik@meinetechnikwelt.rocks>*

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -84,7 +84,8 @@ In host-agent mode the web container reaches the agent via `host.docker.internal
 ├── db.credentials[.example]   ← database passwords (not in VCS)
 ├── .github/
 │   └── workflows/
-│       └── docker-release.yml      ← builds & pushes Docker Hub images on GitHub release
+│       ├── docker-release.yml          ← builds & pushes Docker Hub images on GitHub release
+│       └── auto-patch-release.yml      ← increments patch version and creates a GitHub release (triggered on base image rebuild)
 ├── docker/
 │   ├── docker-compose.yml          ← host-agent mode (web + MariaDB)
 │   ├── docker-compose-agent.yml    ← docker mode (agent + web + MariaDB, file-mounted source)
@@ -1324,7 +1325,7 @@ these images have all PHP source and Composer dependencies baked in.
 | Image | Base | Entrypoint behaviour |
 |---|---|---|
 | `cs1711/cronmanager-agent` | `cs1711/cs_cronmanageragent:latest` (Debian Trixie, PHP 8.4 CLI, cron, openssh-client) | Generates `config.json`, waits for MariaDB, applies schema, starts cron daemon, then `exec php -S` |
-| `cs1711/cronmanager-web` | `cs1711/cs_php-nginx-fpm:latest-alpine` (Alpine, PHP 8.4 FPM, Nginx, supervisord) | Generates `config.json`, fixes volume ownership, then `su-exec nobody supervisord` |
+| `cs1711/cronmanager-web` | `cs1711/cs_php-nginx-fpm:latest-alpine` (Alpine, PHP 8.4 FPM, Nginx, supervisord) | Generates `config.json`, fixes volume ownership (`/var/www/conf`, `/var/www/log`), then `exec /usr/bin/supervisord` as root; nginx worker and PHP-FPM pool drop to `nobody` internally |
 
 ### Build pipeline
 
@@ -1346,6 +1347,28 @@ automatically from the release version (e.g. `v2.1.0`):
 
 Multi-platform builds target `linux/amd64` and `linux/arm64`.
 
+### Automatic patch releases for base image updates
+
+When the upstream base images (`cs1711/cs_cronmanageragent` or `cs1711/cs_php-nginx-fpm`) are
+rebuilt, the `.github/workflows/auto-patch-release.yml` workflow can be triggered either via
+`workflow_dispatch` (manually from the GitHub Actions UI) or via `repository_dispatch` (from a
+CI machine using `curl` or `gh workflow run`).
+
+The workflow reads the latest git tag, increments the patch digit (e.g. `2.1.0` → `2.1.1`),
+and creates a new GitHub release.  This in turn fires `docker-release.yml` via the
+`release: published` trigger, which rebuilds and pushes the Cronmanager images with the updated
+base image baked in.
+
+```
+base image rebuild
+       │
+       ▼ (workflow_dispatch / repository_dispatch)
+auto-patch-release.yml → gh release create v2.x.(n+1)
+       │
+       ▼ (release: published trigger)
+docker-release.yml → docker build + push to Docker Hub
+```
+
 ### Config-from-environment pattern
 
 Both containers generate their `config.json` at every start — no config volume is required.
@@ -1366,8 +1389,17 @@ Both containers generate their `config.json` at every start — no config volume
 ```
 1. php84 -r "echo json_encode([...])"  →  /var/www/conf/config.json
 2. chown -R nobody:nobody /var/www/conf /var/www/log
-3. exec su-exec nobody supervisord
+3. exec /usr/bin/supervisord            (runs as root)
+   ├── nginx:     worker user = nobody  (patched in Dockerfile)
+   └── php-fpm:   pool user = nobody, listen.owner = nobody,
+                  listen.group = nobody, listen.mode = 0660
+                  (patched in Dockerfile)
 ```
+
+> **Why root for supervisord?** Alpine's `cs_php-nginx-fpm` base image does not include
+> `su-exec`. Supervisord must start as root so it can bind ports and manage child process
+> lifecycle. nginx and PHP-FPM then drop to `nobody` via their own configuration, keeping
+> the effective attack surface identical to a `su-exec` approach.
 
 ### Vendor path inside containers
 


### PR DESCRIPTION
- CHANGELOG: add [2.2.0] section covering Alpine sh fix, supervisord privilege model, PHP-FPM/nginx socket permissions, missing assets, mariadb:lts, SSH key mount default, auto-patch-release workflow, Node.js 24 CI fix, and simple_debian_setup.sh host-agent-only refactor
- README: fix mariadb:latest → mariadb:lts in Docker Hub stack table
- TECHNICAL: add auto-patch-release.yml to directory layout; update web container image summary and entrypoint description to reflect removal of su-exec and supervisord-as-root privilege model; add Automatic Patch Releases subsection
- SECURITY: expand Finding 2.4 transport encryption to cover all three deployment modes (host-agent, docker, Docker Hub); update last-updated date