### PR TITLE
feat: TLS for agent communication via nginx reverse proxy (v2.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [2.8.0] – branch: `notify_after_failures`
+## [2.8.0] – branches: `notify_after_failures`, `tls_agent`
 
 ### Added
 - New per-job setting **"Notify after N consecutive failures"** (`notify_after_failures`, default 1).
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Exit code `-4` (maintenance-window skip) does not advance the failure counter.
   - Database migration `008_notify_after_failures.sql` adds the new column to `cronjobs`.
 - Notification messages (e-mail and Telegram) include a footer when the threshold is > 1, stating that no further alerts will be sent until the job recovers.
+- **TLS for agent communication** – the agent container now runs an nginx reverse proxy that terminates TLS on port 8865, forwarding plain HTTP internally to the PHP built-in server.
+  - A 2048-bit RSA self-signed certificate is auto-generated on first start when no certificate files are found.
+  - Custom certificates can be provided by mounting `TLS_CERT_FILE` / `TLS_KEY_FILE` paths.
+  - TLS can be disabled per-container via `AGENT_TLS_ENABLED=false` for trusted internal deployments.
+  - `HostAgentClient` gains `agent.ssl_verify` and `agent.ssl_ca_bundle` config keys for flexible certificate verification.
+  - All compose files and the example `.env` updated to use `https://` agent URLs by default.
 
 ### Changed
 - `ExportEndpoint` now exports all advanced job fields (`execution_limit_seconds`, `auto_kill_on_limit`, `singleton`, `run_in_maintenance`, `retention_days`, `retry_count`, `retry_delay_minutes`, `notify_after_failures`) for a complete job backup.

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ Browser
 │  Web UI (Docker)         │  PHP-FPM + Nginx  ·  Port 8880
 │  /opt/cronmanager/www    │
 └────────────┬─────────────┘
-             │ HMAC-signed HTTP (host.docker.internal:8865)
+             │ HMAC-signed HTTPS (host.docker.internal:8865)
              ▼
 ┌──────────────────────────┐
-│  Host Agent              │  PHP CLI server  ·  Port 8865
+│  Host Agent              │  nginx (TLS) → PHP CLI server  ·  Port 8865
 │  /opt/cronmanager/agent  │  systemd service on the Docker host
 └────────────┬─────────────┘
              │ reads/writes crontab files
@@ -102,6 +102,7 @@ Browser
 
 The agent runs directly on the Docker host. The web container reaches it via
 `host.docker.internal:8865` (provided by Docker's `extra_hosts: host-gateway` mechanism).
+Communication is encrypted with TLS; see [Agent TLS](#agent-tls) for details.
 
 ### Docker mode
 
@@ -113,10 +114,10 @@ Browser
 │  Web UI (Docker)         │  PHP-FPM + Nginx  ·  Port 8880
 │  /opt/cronmanager/www    │
 └────────────┬─────────────┘
-             │ HMAC-signed HTTP (cronmanager-agent:8865)
+             │ HMAC-signed HTTPS (cronmanager-agent:8865)
              ▼
 ┌──────────────────────────┐
-│  Agent container         │  PHP CLI server  ·  Port 8865
+│  Agent container         │  nginx (TLS) → PHP CLI server  ·  Port 8865
 │  cs1711/cs_cronmanageragent  (internal Docker network)
 └────────────┬─────────────┘
              │ manages container's crontab (root)
@@ -130,7 +131,7 @@ All three services share a private `cronmanager-internal` Docker network.
 No PHP installation is required on the host.
 
 The web container never touches crontab files directly.
-All privileged operations are delegated to the agent via HMAC-secured HTTP calls.
+All privileged operations are delegated to the agent via HMAC-secured HTTPS calls.
 
 A MariaDB container (`cronmanager-db`) stores users, job metadata, tags, and execution logs.
 
@@ -228,7 +229,10 @@ commented-out lines in `docker-compose-full.yml`.
 | Variable | Default | Description |
 |---|---|---|
 | `AGENT_BIND_ADDRESS` | `0.0.0.0` | Bind address for the PHP HTTP server |
-| `AGENT_PORT` | `8865` | Listening port |
+| `AGENT_PORT` | `8865` | Listening port (used by nginx TLS terminator) |
+| `AGENT_TLS_ENABLED` | `true` | Enable nginx TLS reverse proxy (set `false` only for trusted internal networks) |
+| `TLS_CERT_FILE` | `/opt/cronmanager/agent/tls/cert.pem` | Path to TLS certificate inside the container (auto-generated self-signed if absent) |
+| `TLS_KEY_FILE` | `/opt/cronmanager/agent/tls/key.pem` | Path to TLS private key inside the container |
 | `DB_HOST` | `cronmanager-db` | MariaDB hostname |
 | `LOG_PATH` | `/opt/cronmanager/agent/log/cronmanager-agent.log` | Log file path |
 | `LOG_LEVEL` | `info` | Monolog level (`debug`, `info`, `warning`, `error`) |
@@ -251,8 +255,10 @@ commented-out lines in `docker-compose-full.yml`.
 
 | Variable | Default | Description |
 |---|---|---|
-| `AGENT_URL` | `http://cronmanager-agent:8865` | Agent base URL |
+| `AGENT_URL` | `https://cronmanager-agent:8865` | Agent base URL |
 | `AGENT_TIMEOUT` | `10` | HTTP timeout in seconds |
+| `AGENT_SSL_VERIFY` | `false` | Verify agent TLS certificate (`false` = accept self-signed; `true` = require trusted CA) |
+| `AGENT_SSL_CA_BUNDLE` | _(empty)_ | Path to a custom CA bundle PEM inside the container (used when `AGENT_SSL_VERIFY=true` with a private CA) |
 | `DB_HOST` | `cronmanager-db` | MariaDB hostname |
 | `LOG_PATH` | `/var/www/log/cronmanager-web.log` | Log file path |
 | `LOG_LEVEL` | `info` | Monolog level |
@@ -654,8 +660,8 @@ sudo journalctl -u cronmanager-agent -f
 # Restart after a config change
 sudo systemctl restart cronmanager-agent
 
-# Verify the agent is reachable
-curl http://127.0.0.1:8865/health
+# Verify the agent is reachable (TLS with self-signed cert)
+curl -k https://127.0.0.1:8865/health
 # → {"status":"ok","timestamp":"2026-03-18T10:00:00+00:00"}
 ```
 
@@ -678,17 +684,21 @@ On the first deployment, the example configuration is placed there automatically
         "password": "<same-as-DB_PASSWORD-in-db.credentials>"
     },
     "agent": {
-        "url": "http://host.docker.internal:8865",
+        "url": "https://host.docker.internal:8865",
         "hmac_secret": "<same-secret-as-in-agent-config>",
-        "timeout": 10
+        "timeout": 10,
+        "ssl_verify": false,
+        "ssl_ca_bundle": ""
     }
 }
 ```
 
-> **Docker mode:** set `agent.url` to `http://cronmanager-agent:8865` instead. `deploy.sh --docker full` patches this automatically on the first deployment.
+> **Docker mode:** set `agent.url` to `https://cronmanager-agent:8865` instead. `deploy.sh --docker full` patches this automatically on the first deployment.
 
 `host.docker.internal` resolves to the Docker host from within the container and is
 configured automatically via the `extra_hosts` entry in `docker/docker-compose.yml` (host-agent mode). In docker mode, use `cronmanager-agent` as the hostname instead — this is the Docker service name on the shared internal network.
+
+`ssl_verify: false` is correct for the default self-signed certificate. Set it to `true` and supply `ssl_ca_bundle` when using a certificate signed by a private CA.
 
 ---
 
@@ -854,9 +864,11 @@ provider — the account will be re-created on the next login.
 | `database.name` | `cronmanager` | Database name |
 | `database.user` | `cronmanager` | Database user |
 | `database.password` | | Database password |
-| `agent.url` | `http://host.docker.internal:8865` (host-agent) / `http://cronmanager-agent:8865` (docker) | Host agent base URL |
+| `agent.url` | `https://host.docker.internal:8865` (host-agent) / `https://cronmanager-agent:8865` (docker) | Host agent base URL |
 | `agent.hmac_secret` | | Shared HMAC secret (must match agent) |
 | `agent.timeout` | `10` | HTTP timeout in seconds |
+| `agent.ssl_verify` | `false` | `false` = accept self-signed cert; `true` = require trusted CA; path string = use custom CA bundle |
+| `agent.ssl_ca_bundle` | `""` | Path to a PEM CA bundle inside the container (used when `ssl_verify` is `true` with a private CA) |
 | `logging.path` | `/var/www/log/cronmanager-web.log` | Log file path |
 | `logging.level` | `info` | `debug`, `info`, `warning`, `error`, `critical` |
 | `logging.max_days` | `30` | Log file retention in days |
@@ -876,8 +888,9 @@ provider — the account will be re-created on the next login.
 
 | Key | Default | Description |
 |---|---|---|
-| `agent.bind_address` | `0.0.0.0` | Listen address (`127.0.0.1` to restrict to localhost) |
-| `agent.port` | `8865` | Listen port |
+| `agent.bind_address` | `0.0.0.0` | Bind address for the internal PHP server (nginx handles the external port) |
+| `agent.port` | `8865` | External port (nginx TLS) |
+| `agent.tls_enabled` | `true` | Written automatically from `AGENT_TLS_ENABLED`; read by `cron-wrapper.sh` to decide HTTP vs HTTPS |
 | `agent.hmac_secret` | | Shared HMAC secret (must match web config) |
 | `database.host` | `127.0.0.1` | MariaDB hostname |
 | `database.port` | `3306` | MariaDB port |
@@ -902,6 +915,51 @@ provider — the account will be re-created on the next login.
 | `telegram.chat_id` | | Target chat, channel, or group ID |
 | `telegram.timeout` | `15` | HTTP request timeout in seconds |
 | `cron.wrapper_script` | `/opt/cronmanager/agent/bin/cron-wrapper.sh` | Wrapper script path |
+
+---
+
+## Agent TLS
+
+All communication between the web container and the host agent is encrypted with TLS.
+The agent container runs an **nginx reverse proxy** that terminates TLS on port **8865**
+and forwards plain HTTP internally to the PHP built-in server on port **18865**.
+
+### Certificate
+
+By default a **self-signed RSA-2048 certificate** (valid 10 years) is generated
+automatically on the first container start and stored in a Docker-managed named volume
+(`agent-tls`) so it persists across container recreations.
+
+To use your own certificate (Let's Encrypt, private CA, etc.), mount the cert and key
+files into the container and set the corresponding environment variables:
+
+```yaml
+environment:
+  TLS_CERT_FILE: /opt/cronmanager/agent/tls/cert.pem
+  TLS_KEY_FILE:  /opt/cronmanager/agent/tls/key.pem
+volumes:
+  - /path/to/your/cert.pem:/opt/cronmanager/agent/tls/cert.pem:ro
+  - /path/to/your/key.pem:/opt/cronmanager/agent/tls/key.pem:ro
+```
+
+### Web container – certificate verification
+
+Set `agent.ssl_verify` (or `AGENT_SSL_VERIFY`) on the web container:
+
+| Value | When to use |
+|---|---|
+| `false` | Self-signed certificate (default) |
+| `true` | Certificate from a public/trusted CA |
+| `/path/to/ca.pem` | Certificate from a private CA – provide the CA bundle path |
+
+When using a custom CA bundle, also set `agent.ssl_ca_bundle` to the path of the PEM
+file **inside the web container**.
+
+### Disabling TLS
+
+TLS can be disabled by setting `AGENT_TLS_ENABLED=false` on the agent container and
+changing `agent.url` back to `http://` in the web config. This is only recommended
+for isolated internal networks where encryption is provided at another layer.
 
 ---
 
@@ -1168,9 +1226,9 @@ ssh myserver 'docker exec -i cronmanager-db mariadb \
 1. Check the agent is running:
    ```bash
    sudo systemctl status cronmanager-agent
-   curl http://127.0.0.1:8865/health
+   curl -k https://127.0.0.1:8865/health
    ```
-2. Verify `agent.url` in the web config points to `http://host.docker.internal:8865`
+2. Verify `agent.url` in the web config points to `https://host.docker.internal:8865` and `ssl_verify` is `false`
 3. Verify the HMAC secret matches in both config files
 4. Inspect agent logs:
    ```bash
@@ -1183,9 +1241,9 @@ ssh myserver 'docker exec -i cronmanager-db mariadb \
 1. Check the agent container is running and healthy:
    ```bash
    docker ps | grep cronmanager-agent
-   docker exec cronmanager-agent curl -s http://localhost:8865/health
+   docker exec cronmanager-agent curl -sk https://localhost:8865/health
    ```
-2. Verify `agent.url` in the web config points to `http://cronmanager-agent:8865`
+2. Verify `agent.url` in the web config points to `https://cronmanager-agent:8865` and `ssl_verify` is `false`
 3. Verify the HMAC secret matches in both config files
 4. Inspect agent container logs:
    ```bash

--- a/agent/bin/cron-wrapper.sh
+++ b/agent/bin/cron-wrapper.sh
@@ -128,13 +128,22 @@ read_config() {
 BIND_ADDRESS="$(read_config 'agent.bind_address' '0.0.0.0')"
 AGENT_PORT="$(read_config 'agent.port' '8865')"
 HMAC_SECRET="$(read_config 'agent.hmac_secret' '')"
+AGENT_TLS_ENABLED="$(read_config 'agent.tls_enabled' 'false')"
 
 # Replace wildcard bind address with loopback for outgoing connections
 if [[ "$BIND_ADDRESS" == "0.0.0.0" ]]; then
     BIND_ADDRESS="127.0.0.1"
 fi
 
-readonly AGENT_BASE_URL="http://${BIND_ADDRESS}:${AGENT_PORT}"
+# When TLS is enabled nginx listens externally; PHP is on an internal port.
+# Connections from within the same container always go to localhost via nginx.
+if [[ "${AGENT_TLS_ENABLED}" == "1" || "${AGENT_TLS_ENABLED}" == "true" ]]; then
+    readonly AGENT_BASE_URL="https://${BIND_ADDRESS}:${AGENT_PORT}"
+    readonly AGENT_TLS_INSECURE="--insecure"   # allow self-signed certificates
+else
+    readonly AGENT_BASE_URL="http://${BIND_ADDRESS}:${AGENT_PORT}"
+    readonly AGENT_TLS_INSECURE=""
+fi
 
 if [[ -z "$HMAC_SECRET" ]]; then
     log_warn "HMAC secret is empty – requests will be rejected by the agent"
@@ -202,6 +211,11 @@ agent_request() {
         --write-out '%{http_code}'
         --output "${tmp_file}"
     )
+
+    # Add --insecure when talking to a self-signed TLS certificate
+    if [[ -n "${AGENT_TLS_INSECURE:-}" ]]; then
+        curl_args+=("${AGENT_TLS_INSECURE}")
+    fi
 
     if [[ "$method" == "POST" ]]; then
         curl_args+=(

--- a/deploy.sh
+++ b/deploy.sh
@@ -551,7 +551,7 @@ if [[ "${DEPLOY_WEB_PART}" == "true" ]]; then
             copy_to_target "${WEB_SRC}/config/config.json" "${WEB_CONF_TARGET}/config.json"
             # Patch agent.url for docker mode (web → agent via Docker service name)
             if [[ "${DEPLOY_TARGET}" == "docker" ]]; then
-                log "Docker mode: patching web config agent.url → http://cronmanager-agent:8865..."
+                log "Docker mode: patching web config agent.url → https://cronmanager-agent:8865..."
                 _run_remote_python \
 'import json, re, sys
 path = sys.argv[1]
@@ -561,7 +561,9 @@ if isinstance(cfg.get("agent"), dict) and "url" in cfg["agent"]:
     url = cfg["agent"]["url"]
     m = re.search(r":(\d+)", url)
     port = m.group(1) if m else "8865"
-    cfg["agent"]["url"] = "http://cronmanager-agent:" + port
+    cfg["agent"]["url"] = "https://cronmanager-agent:" + port
+    cfg["agent"]["ssl_verify"] = False
+    cfg["agent"]["ssl_ca_bundle"] = ""
 with open(path, "w") as fh:
     json.dump(cfg, fh, indent=4, ensure_ascii=False)
 print("[deploy] Web config agent.url patched.")' \
@@ -690,7 +692,7 @@ print("[deploy] Agent config patched successfully.")' \
     # Changes: agent.url host.docker.internal:PORT → cronmanager-agent:PORT
 
     if run_on_target "test -f '${WEB_CONFIG_FILE}'" 2>/dev/null; then
-        log "Patching web config.json (agent.url → docker service name)..."
+        log "Patching web config.json (agent.url → docker service name, TLS)..."
         _run_remote_python \
 'import json, re, sys
 path = sys.argv[1]
@@ -700,7 +702,9 @@ if isinstance(cfg.get("agent"), dict) and "url" in cfg["agent"]:
     url = cfg["agent"]["url"]
     m = re.search(r":(\d+)", url)
     port = m.group(1) if m else "8865"
-    cfg["agent"]["url"] = "http://cronmanager-agent:" + port
+    cfg["agent"]["url"] = "https://cronmanager-agent:" + port
+    cfg["agent"]["ssl_verify"] = False
+    cfg["agent"]["ssl_ca_bundle"] = ""
 with open(path, "w") as fh:
     json.dump(cfg, fh, indent=4, ensure_ascii=False)
 print("[deploy] Web config patched successfully.")' \

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -36,6 +36,20 @@ SESSION_LIFETIME=3600
 # ── Agent HTTP timeout (seconds) ─────────────────────────────────────────────
 AGENT_TIMEOUT=10
 
+# ── Agent TLS ────────────────────────────────────────────────────────────────
+# Enable nginx TLS termination on the agent container (default: true).
+# Set to false only for local development or trusted internal networks.
+AGENT_TLS_ENABLED=true
+
+# Path to a custom TLS certificate and key inside the agent container.
+# When not set, a self-signed certificate is auto-generated on first start.
+# TLS_CERT_FILE=/opt/cronmanager/agent/tls/cert.pem
+# TLS_KEY_FILE=/opt/cronmanager/agent/tls/key.pem
+
+# Web → Agent TLS options (set on the web container):
+# AGENT_SSL_VERIFY=false   – set false when using the auto-generated self-signed cert
+# AGENT_SSL_CA_BUNDLE=     – path to a CA bundle PEM for custom CA certificates
+
 # ── Email failure alerts (optional) ──────────────────────────────────────────
 # MAIL_ENABLED=true
 # MAIL_HOST=smtp.example.com

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -6,9 +6,12 @@
 #   1. Generate /opt/cronmanager/agent/config/config.json from environment variables.
 #   2. Wait for MariaDB and apply schema.sql if the 'cronjobs' table is missing.
 #   3. Fix SSH key permissions (host-mounted keys are often 644).
-#   4. Start the system cron daemon in the background.
-#   5. Read bind address and port from the generated config and start the PHP
+#   4. Configure nginx TLS reverse proxy (when AGENT_TLS_ENABLED=true).
+#   5. Start the system cron daemon in the background.
+#   6. Read bind address and port from the generated config and start the PHP
 #      built-in server as the foreground process (PID 1 equivalent).
+#      When TLS is enabled, PHP binds on 127.0.0.1:18865 and nginx terminates
+#      TLS on 0.0.0.0:8865, proxying to the PHP server.
 #
 # Required environment variables:
 #   AGENT_HMAC_SECRET   – shared secret for HMAC-SHA256 request signing
@@ -38,6 +41,9 @@
 #   TELEGRAM_CHAT_ID    ""
 #   TELEGRAM_TIMEOUT    15
 #   CRON_WRAPPER_SCRIPT /opt/cronmanager/agent/bin/cron-wrapper.sh
+#   AGENT_TLS_ENABLED   true
+#   TLS_CERT_FILE       /opt/cronmanager/agent/tls/cert.pem
+#   TLS_KEY_FILE        /opt/cronmanager/agent/tls/key.pem
 #
 # @author  Christian Schulz <technik@meinetechnikwelt.rocks>
 # @license GNU General Public License version 3 or later
@@ -78,6 +84,7 @@ php -r "
         'bind_address' => getenv('AGENT_BIND_ADDRESS') ?: '0.0.0.0',
         'port'         => (int)(getenv('AGENT_PORT') ?: 8865),
         'hmac_secret'  => getenv('AGENT_HMAC_SECRET'),
+        'tls_enabled'  => filter_var(getenv('AGENT_TLS_ENABLED') ?: 'true', FILTER_VALIDATE_BOOLEAN),
     ],
     'database' => [
         'host'     => getenv('DB_HOST') ?: 'cronmanager-db',
@@ -319,6 +326,7 @@ fi
 #    We copy the keys to a writable location and fix permissions there.
 # =============================================================================
 
+
 if [[ -d /root/.ssh ]]; then
     SSH_PERMS_OK=true
 
@@ -343,7 +351,99 @@ else
 fi
 
 # =============================================================================
-# 3. Resync crontab from database
+# 4. Configure nginx TLS reverse proxy
+#    When AGENT_TLS_ENABLED=true, nginx terminates TLS on 0.0.0.0:8865 and
+#    forwards plain HTTP to the PHP built-in server on 127.0.0.1:18865.
+#    A self-signed certificate is generated automatically when no cert files
+#    are found at the configured paths.
+# =============================================================================
+
+AGENT_TLS_ENABLED="${AGENT_TLS_ENABLED:-true}"
+TLS_CERT_FILE="${TLS_CERT_FILE:-/opt/cronmanager/agent/tls/cert.pem}"
+TLS_KEY_FILE="${TLS_KEY_FILE:-/opt/cronmanager/agent/tls/key.pem}"
+TLS_INTERNAL_PORT=18865
+
+if [[ "${AGENT_TLS_ENABLED}" == "true" ]]; then
+    log_info "TLS enabled – configuring nginx reverse proxy..."
+
+    TLS_DIR=$(dirname "${TLS_CERT_FILE}")
+    mkdir -p "${TLS_DIR}"
+
+    # Auto-generate a self-signed certificate when none exists
+    if [[ ! -f "${TLS_CERT_FILE}" ]] || [[ ! -f "${TLS_KEY_FILE}" ]]; then
+        log_info "No TLS certificate found at ${TLS_CERT_FILE} – generating self-signed certificate..."
+        TLS_CERT_FILE="${TLS_CERT_FILE}" TLS_KEY_FILE="${TLS_KEY_FILE}" php -r "
+            \$key = openssl_pkey_new([
+                'private_key_bits' => 2048,
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]);
+            if (!\$key) {
+                fwrite(STDERR, 'openssl_pkey_new failed: ' . implode(', ', array_reverse(array_keys(openssl_error_string() ? [] : []))) . PHP_EOL);
+                exit(1);
+            }
+            \$csr = openssl_csr_new(
+                ['CN' => 'cronmanager-agent', 'O' => 'Cronmanager'],
+                \$key,
+                ['digest_alg' => 'sha256']
+            );
+            \$cert = openssl_csr_sign(\$csr, null, \$key, 3650, ['digest_alg' => 'sha256'], 0);
+            openssl_x509_export(\$cert, \$certPem);
+            openssl_pkey_export(\$key, \$keyPem);
+            file_put_contents(getenv('TLS_CERT_FILE'), \$certPem);
+            file_put_contents(getenv('TLS_KEY_FILE'), \$keyPem);
+            chmod(getenv('TLS_KEY_FILE'), 0600);
+            echo 'Certificate written.' . PHP_EOL;
+        " || { log_error "Failed to generate self-signed TLS certificate."; exit 1; }
+        log_info "Self-signed TLS certificate generated (valid 10 years)."
+    else
+        log_info "TLS certificate found at ${TLS_CERT_FILE}."
+    fi
+
+    # Remove the default nginx site to avoid port conflicts
+    rm -f /etc/nginx/sites-enabled/default
+
+    # Use the configured external port (from env var; config.json is not yet read at this point)
+    AGENT_EXTERNAL_PORT="${AGENT_PORT:-8865}"
+
+    # Write the agent nginx vhost
+    cat > /etc/nginx/sites-enabled/cronmanager-agent.conf << NGINX_EOF
+server {
+    listen 0.0.0.0:${AGENT_EXTERNAL_PORT} ssl;
+
+    ssl_certificate     ${TLS_CERT_FILE};
+    ssl_certificate_key ${TLS_KEY_FILE};
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    access_log /dev/stdout;
+    error_log  /dev/stderr;
+
+    location / {
+        proxy_pass         http://127.0.0.1:${TLS_INTERNAL_PORT};
+        proxy_set_header   Host \$host;
+        proxy_set_header   X-Real-IP \$remote_addr;
+        proxy_read_timeout 60;
+        proxy_connect_timeout 10;
+    }
+}
+NGINX_EOF
+
+    # Validate config and start nginx
+    if nginx -t 2>&1; then
+        nginx
+        log_info "nginx TLS reverse proxy started (0.0.0.0:${AGENT_EXTERNAL_PORT} → 127.0.0.1:${TLS_INTERNAL_PORT})."
+    else
+        log_error "nginx configuration test failed – aborting."
+        exit 1
+    fi
+else
+    log_info "TLS disabled (AGENT_TLS_ENABLED=${AGENT_TLS_ENABLED})."
+fi
+
+# =============================================================================
+# 5. Resync crontab from database
 #    Rebuilds all crontab entries so that jobs are never lost after a
 #    container recreation (e.g. Portainer stack redeploy, image update).
 # =============================================================================
@@ -362,7 +462,7 @@ else
 fi
 
 # =============================================================================
-# 4. Install execution-limit checker cron entry and start cron daemon
+# 5b. Install execution-limit checker cron entry and start cron daemon
 # =============================================================================
 
 LIMITS_CRON_FILE="/etc/cron.d/cronmanager-limits"
@@ -380,7 +480,11 @@ CRON_PID=$!
 log_info "Cron daemon started (PID ${CRON_PID})."
 
 # =============================================================================
-# 5. Start PHP built-in server (foreground – becomes main process)
+# 6. Start PHP built-in server (foreground – becomes main process)
+#
+#    TLS mode  : PHP binds on 127.0.0.1:18865 (internal only); nginx handles
+#                the external TLS port 8865.
+#    Plain mode: PHP binds on AGENT_BIND_ADDRESS:AGENT_PORT (default 0.0.0.0:8865).
 # =============================================================================
 
 # Re-read bind address and port from the generated config file
@@ -395,6 +499,13 @@ if [[ -f "$CONFIG_FILE" ]]; then
     " 2>/dev/null || echo "0.0.0.0 8865")
     BIND_ADDRESS="${_parsed%% *}"
     PORT="${_parsed##* }"
+fi
+
+# When TLS is enabled, nginx owns the external port – PHP binds internally only
+if [[ "${AGENT_TLS_ENABLED}" == "true" ]]; then
+    BIND_ADDRESS="127.0.0.1"
+    PORT="${TLS_INTERNAL_PORT}"
+    log_info "TLS mode: PHP built-in server binding on ${BIND_ADDRESS}:${PORT} (nginx on :${AGENT_PORT:-8865})"
 fi
 
 AGENT_PHP="${AGENT_DIR}/agent.php"

--- a/docker/docker-compose-agent.yml
+++ b/docker/docker-compose-agent.yml
@@ -42,6 +42,8 @@ services:
       - /opt/cronmanager/agent:/opt/cronmanager/agent:ro
       - /opt/cronmanager/agent/config:/opt/cronmanager/agent/config
       - /opt/cronmanager/agent/log:/opt/cronmanager/agent/log
+      # TLS certificates – persisted so the auto-generated cert survives restarts
+      - /opt/cronmanager/agent/tls:/opt/cronmanager/agent/tls
       # SSH keys for remote job execution
       - /root/.ssh:/root/.ssh:ro
       # Shared PHP libraries

--- a/docker/docker-compose-full.yml
+++ b/docker/docker-compose-full.yml
@@ -64,9 +64,12 @@ services:
       DB_PORT:  "3306"
       DB_NAME:  "${DB_NAME:-cronmanager}"
       DB_USER:  "${DB_USER:-cronmanager}"
-      # Agent HTTP server
-      AGENT_BIND_ADDRESS: "0.0.0.0"
-      AGENT_PORT:         "8865"
+      # Agent HTTP/TLS server
+      AGENT_BIND_ADDRESS:  "0.0.0.0"
+      AGENT_PORT:          "8865"
+      AGENT_TLS_ENABLED:   "true"
+      # TLS_CERT_FILE:     "/opt/cronmanager/agent/tls/cert.pem"   # auto-generated if omitted
+      # TLS_KEY_FILE:      "/opt/cronmanager/agent/tls/key.pem"    # auto-generated if omitted
       # Logging
       LOG_PATH:     "/opt/cronmanager/agent/log/cronmanager-agent.log"
       LOG_LEVEL:    "${LOG_LEVEL:-info}"
@@ -93,6 +96,10 @@ services:
       - agent-log:/opt/cronmanager/agent/log
       # Optional: persist logs on the host instead
       # - /opt/cronmanager/agent/log:/opt/cronmanager/agent/log
+      # TLS certificates – persisted so the auto-generated cert survives restarts
+      - agent-tls:/opt/cronmanager/agent/tls
+      # Optional: mount your own certificate/key instead of using the auto-generated one
+      # - /opt/cronmanager/agent/tls:/opt/cronmanager/agent/tls
       - /etc/localtime:/etc/localtime:ro
       # SSH keys for remote job execution and crontab import.
       # The default mounts the host root user's full SSH config.
@@ -121,9 +128,11 @@ services:
       # Required
       AGENT_HMAC_SECRET: "${AGENT_HMAC_SECRET}"
       DB_PASSWORD:        "${DB_PASSWORD}"
-      # Agent connection (uses Docker service name)
-      AGENT_URL:     "http://cronmanager-agent:8865"
-      AGENT_TIMEOUT: "${AGENT_TIMEOUT:-10}"
+      # Agent connection (uses Docker service name; TLS, self-signed cert)
+      AGENT_URL:            "https://cronmanager-agent:8865"
+      AGENT_TIMEOUT:        "${AGENT_TIMEOUT:-10}"
+      AGENT_SSL_VERIFY:     "false"
+      AGENT_SSL_CA_BUNDLE:  ""
       # Database
       DB_HOST: "cronmanager-db"
       DB_PORT: "3306"
@@ -160,6 +169,7 @@ services:
 volumes:
   db-data:
   agent-log:
+  agent-tls:
   web-log:
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,11 @@ services:
     extra_hosts:
       # Allows the web container to reach the host agent on the Docker host
       - "host.docker.internal:host-gateway"
+    environment:
+      # Agent URL – update to https:// when the host agent runs with TLS enabled
+      AGENT_URL:           "https://host.docker.internal:8865"
+      AGENT_SSL_VERIFY:    "false"
+      AGENT_SSL_CA_BUNDLE: ""
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /opt/cronmanager/www/conf:/var/www/conf

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -12,8 +12,10 @@
 #   DB_PASSWORD         – MariaDB password for the application user
 #
 # Optional environment variables (shown with their defaults):
-#   AGENT_URL           http://cronmanager-agent:8865
+#   AGENT_URL           https://cronmanager-agent:8865
 #   AGENT_TIMEOUT       10
+#   AGENT_SSL_VERIFY    false
+#   AGENT_SSL_CA_BUNDLE ""
 #   DB_HOST             cronmanager-db
 #   DB_PORT             3306
 #   DB_NAME             cronmanager
@@ -74,9 +76,11 @@ php84 -r "
         'password' => getenv('DB_PASSWORD'),
     ],
     'agent' => [
-        'url'         => getenv('AGENT_URL') ?: 'http://cronmanager-agent:8865',
-        'hmac_secret' => getenv('AGENT_HMAC_SECRET'),
-        'timeout'     => (int)(getenv('AGENT_TIMEOUT') ?: 10),
+        'url'            => getenv('AGENT_URL') ?: 'https://cronmanager-agent:8865',
+        'hmac_secret'    => getenv('AGENT_HMAC_SECRET'),
+        'timeout'        => (int)(getenv('AGENT_TIMEOUT') ?: 10),
+        'ssl_verify'     => filter_var(getenv('AGENT_SSL_VERIFY') ?: 'false', FILTER_VALIDATE_BOOLEAN),
+        'ssl_ca_bundle'  => getenv('AGENT_SSL_CA_BUNDLE') ?: '',
     ],
     'logging' => [
         'path'     => getenv('LOG_PATH') ?: '/var/www/log/cronmanager-web.log',

--- a/web/config/config.json
+++ b/web/config/config.json
@@ -7,9 +7,11 @@
         "password": "cronmanagerpassword"
     },
     "agent": {
-        "url": "http://host.docker.internal:8865",
+        "url": "https://host.docker.internal:8865",
         "hmac_secret": "change-me-to-a-secure-random-string",
-        "timeout": 10
+        "timeout": 10,
+        "ssl_verify": false,
+        "ssl_ca_bundle": ""
     },
     "logging": {
         "path": "/var/www/log/cronmanager-web.log",

--- a/web/src/Agent/HostAgentClient.php
+++ b/web/src/Agent/HostAgentClient.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
  * the agent can verify that the call originated from a trusted source.
  *
  * Config keys used:
- *   agent.url         – Base URL of the host agent (e.g. http://host.docker.internal:8865)
- *   agent.hmac_secret – Shared secret for HMAC-SHA256 request signing
- *   agent.timeout     – Request timeout in seconds (default: 10)
+ *   agent.url            – Base URL of the host agent (e.g. https://host.docker.internal:8865)
+ *   agent.hmac_secret    – Shared secret for HMAC-SHA256 request signing
+ *   agent.timeout        – Request timeout in seconds (default: 10)
+ *   agent.ssl_verify     – Verify TLS certificate (default: true; set false for self-signed certs)
+ *   agent.ssl_ca_bundle  – Path to custom CA bundle PEM (optional; used when ssl_verify is true)
  *
  * Signature algorithm:
  *   X-Agent-Signature: hmac_sha256(secret, UPPER(method) + path + rawBody)
@@ -311,20 +313,41 @@ class HostAgentClient
     // -------------------------------------------------------------------------
 
     /**
-     * Return a lazily-created Guzzle HTTP client configured with the agent base URL
-     * and request timeout from configuration.
+     * Return a lazily-created Guzzle HTTP client configured with the agent base URL,
+     * request timeout, and TLS verification settings from configuration.
+     *
+     * Config keys:
+     *   agent.ssl_verify    – true to verify the server certificate, false to skip
+     *                         (use false for self-signed certs; default: true)
+     *   agent.ssl_ca_bundle – path to a CA bundle PEM file; used when ssl_verify is
+     *                         true and the server uses a certificate from a custom CA
      *
      * @return Client
      */
     private function client(): Client
     {
         if ($this->guzzle === null) {
-            $baseUrl = (string) $this->config->get('agent.url', 'http://host.docker.internal:8865');
-            $timeout = (int)    $this->config->get('agent.timeout', 10);
+            $baseUrl   = (string) $this->config->get('agent.url', 'http://host.docker.internal:8865');
+            $timeout   = (int)    $this->config->get('agent.timeout', 10);
+            $sslVerify = (bool)   $this->config->get('agent.ssl_verify', true);
+            $caBundle  = (string) $this->config->get('agent.ssl_ca_bundle', '');
+
+            // Resolve the 'verify' option for Guzzle:
+            //   false          → disable certificate verification (self-signed)
+            //   '/path/ca.pem' → verify against a custom CA bundle
+            //   true           → use the system CA bundle
+            if (!$sslVerify) {
+                $verify = false;
+            } elseif ($caBundle !== '') {
+                $verify = $caBundle;
+            } else {
+                $verify = true;
+            }
 
             $this->guzzle = new Client([
                 'base_uri'    => rtrim($baseUrl, '/'),
                 'timeout'     => $timeout,
+                'verify'      => $verify,
                 'http_errors' => false,  // We handle error codes ourselves
             ]);
         }


### PR DESCRIPTION
The agent container now runs an nginx reverse proxy that terminates TLS on port 8865, forwarding plain HTTP internally to the PHP built-in server on port 18865.

- A self-signed RSA-2048 certificate is auto-generated on first start using PHP openssl_* functions; cert persists in a named Docker volume
- Custom certificates can be provided via TLS_CERT_FILE / TLS_KEY_FILE
- TLS can be disabled per-deployment via AGENT_TLS_ENABLED=false
- agent config.json gains tls_enabled flag; cron-wrapper.sh reads it to switch between http:// and https:// (with --insecure for self-signed)
- HostAgentClient gains agent.ssl_verify and agent.ssl_ca_bundle config keys for flexible certificate verification on the web side
- All compose files, .env.example, deploy.sh, and config.json examples updated to use https:// agent URLs by default
- README updated: architecture diagrams, env var tables, config reference, new Agent TLS section, troubleshooting commands