### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Description
+<!-- A clear description of what the bug is -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behaviour
+
+
+## Actual Behaviour
+
+
+## Affected Component
+<!-- Check all that apply -->
+- [ ] Web UI
+- [ ] Agent
+- [ ] cron-wrapper.sh
+- [ ] Notifications (email / Telegram)
+- [ ] InfluxDB / metrics
+- [ ] Deployment / deploy.sh
+- [ ] Other: 
+
+## Environment
+- Cronmanager version:
+- Docker / host OS:
+- Browser (if UI issue):
+
+## Relevant Log Output
+<!-- Agent log, web log, or browser console. Paste between the backticks. -->
+```
+(paste here)
+```
+
+## Additional Context
+<!-- Anything else that might help: DB state, config excerpts (redact secrets), screenshots -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,17 @@
+---
+name: Documentation Improvement
+about: Missing, incorrect, or outdated documentation
+labels: documentation
+---
+
+## What needs improving?
+<!-- README, CHANGELOG, inline comments, CLAUDE.md, deployment docs, etc. -->
+
+## Current state
+<!-- What does it say now, or what is missing entirely? -->
+
+## Suggested improvement
+<!-- What should it say, or what should be added? -->
+
+## Additional Context
+<!-- Links to relevant sections, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Summary
+<!-- One or two sentences describing what you want -->
+
+## Motivation / Use Case
+<!-- Why is this useful? What problem does it solve? -->
+
+## Proposed Behaviour
+<!-- Describe how the feature should work from a user's perspective -->
+
+## Affected Component
+<!-- Check all that apply -->
+- [ ] Web UI
+- [ ] Agent
+- [ ] cron-wrapper.sh
+- [ ] Notifications (email / Telegram)
+- [ ] InfluxDB / metrics
+- [ ] Deployment / deploy.sh
+- [ ] New component
+
+## Alternatives Considered
+<!-- Any workarounds or alternative approaches you've thought about -->
+
+## Additional Context
+<!-- Mockups, examples from other tools, related issues -->

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,12 @@
+---
+name: Security Issue
+about: Report a security vulnerability
+labels: security
+---
+
+> [!CAUTION]
+> **Please do not report security vulnerabilities as public issues.**
+>
+> If you have found a security vulnerability, please report it privately by sending an email to **technik@meinetechnikwelt.rocks** with a description of the issue and steps to reproduce it.
+>
+> Public disclosure of security vulnerabilities puts all users at risk. Thank you for reporting responsibly.


### PR DESCRIPTION
## Summary
- Adds four issue templates: bug report, feature request, documentation improvement, and security issue
- Disables blank issues to guide reporters through the appropriate template
- Security template redirects to private email instead of a public issue

## Templates added
| Template | Label |
|---|---|
| Bug Report | `bug` |
| Feature Request | `enhancement` |
| Documentation Improvement | `documentation` |
| Security Issue | `security` (redirects to email) |